### PR TITLE
feat: UI redesign, mentor panel, bug fixes, handlers restructuring

### DIFF
--- a/database/db.py
+++ b/database/db.py
@@ -3338,20 +3338,22 @@ async def send_mentor_assignment_notification(session: AsyncSession, bot, traine
             if mentor_work_object:
                 objects_info += f"📍<b>Объект работы наставника:</b> {mentor_work_object}"
 
-        notification_text = f"""🎯 <b>Тебе назначен наставник!</b>
+        notification_text = f"""🎯 <b>Тебе назначили наставника!</b>
 
 👨‍🏫 <b>Твой наставник:</b> {mentor_name}
 
 📋 <b>Контактная информация:</b>
 {contact_info}{assigned_info}{objects_info}
 
-💡 <b>Что дальше?</b>
-• Свяжитесь с наставником для знакомства
-• Обсудите план обучения и цели стажировки
-• Задавайте вопросы и просите помощь при необходимости
-• Наставник поможет тебе с тестами и заданиями
+________________
 
-🎯 <b>Удачи в обучении!</b>"""
+💡 <b>Что дальше?</b>
+
+• Напиши наставнику и познакомьтесь!
+• Обсуждайте план обучения
+• Задавай вопросы, проси помощь
+
+❤️ Удачи!"""
 
         # Создаем клавиатуру с полезными кнопками
         keyboard_buttons = []
@@ -3365,7 +3367,6 @@ async def send_mentor_assignment_notification(session: AsyncSession, bot, traine
         ])
         
         keyboard_buttons.extend([
-            [InlineKeyboardButton(text="🗺️ Тесты траектории", callback_data="trajectory_tests_shortcut")],
             [InlineKeyboardButton(text="👨‍🏫 Информация о наставнике", callback_data="my_mentor_info")]
         ])
         
@@ -6015,8 +6016,8 @@ async def assign_learning_path_to_trainee(session: AsyncSession, trainee_id: int
         # Создаем прогресс по этапам и сессиям
         await _create_trainee_progress(session, trainee_path.id, learning_path_id)
 
-        # Отправляем уведомление стажеру
-        await send_learning_path_assigned_notification(session, trainee_id, learning_path_id, bot, company_id)
+        # Уведомление о назначении траектории убрано — стажёр сразу получает
+        # уведомление об открытии этапа 1 с кнопкой к прохождению
 
         logger.info(f"Траектория {learning_path_id} назначена стажеру {trainee_id} наставником {mentor_id}")
         return True

--- a/handlers/knowledge/knowledge_base.py
+++ b/handlers/knowledge/knowledge_base.py
@@ -104,7 +104,7 @@ async def start_material_addition(callback: CallbackQuery, state: FSMContext, se
         return False
 
 
-@router.message(F.text.in_(["База знаний", "База знаний 📂", "База знаний 📁", "База знаний 📁️"]))
+@router.message(F.text.in_(["База знаний", "База знаний 📁️", "База знаний 📒"]))
 async def cmd_knowledge_base_universal(message: Message, state: FSMContext, session: AsyncSession):
     """Универсальный обработчик кнопки 'База знаний' для рекрутера, сотрудника и стажера (ТЗ 9-1 шаг 1)"""
     try:

--- a/handlers/tests/test_taking.py
+++ b/handlers/tests/test_taking.py
@@ -75,10 +75,13 @@ async def cmd_trajectory_tests(message: Message, state: FSMContext, session: Asy
     
     if not available_tests:
         await message.answer(
-            "🗺️ <b>Тесты траектории</b>\n\n"
-            "У тебя пока нет доступных тестов для прохождения.\n"
-            "Обратись к наставнику для получения доступа к тестам.",
-            parse_mode="HTML"
+            "Твой наставник пока не назначил тебе тесты 🥹\n\n"
+            "Как только он это сделает, ты сможешь приступить к ним. "
+            "Если хочешь ускорить процесс — свяжись с наставником напрямую",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                [InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]
+            ])
         )
         return
     
@@ -838,10 +841,13 @@ async def callback_trajectory_tests_pagination(callback: CallbackQuery, state: F
             available_tests = await get_trainee_available_tests(session, user.id, company_id=company_id)
             if not available_tests:
                 await callback.message.edit_text(
-                    "🗺️ <b>Тесты траектории</b>\n\n"
-                    "У тебя пока нет доступных тестов для прохождения.\n"
-                    "Обратись к наставнику для получения доступа к тестам.",
-                    parse_mode="HTML"
+                    "Твой наставник пока не назначил тебе тесты 🥹\n\n"
+                    "Как только он это сделает, ты сможешь приступить к ним. "
+                    "Если хочешь ускорить процесс — свяжись с наставником напрямую",
+                    parse_mode="HTML",
+                    reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                        [InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]
+                    ])
                 )
                 return
             # Сохраняем загруженные тесты в state
@@ -1655,7 +1661,7 @@ async def finish_test(message: Message, state: FSMContext, session: AsyncSession
                 for i, test_item in enumerate(current_session.tests, 1):
                     test_keyboard.append([
                         InlineKeyboardButton(
-                            text=f"Тест {i}",
+                            text=test_item.name,
                             callback_data=f"take_test:{current_session.id}:{test_item.id}"
                         )
                     ])
@@ -1823,13 +1829,16 @@ async def process_back_to_test_list(callback: CallbackQuery, state: FSMContext, 
     if is_from_trajectory:
         # ТЕСТЫ ТРАЕКТОРИИ
         available_tests = await get_trainee_available_tests(session, user.id, company_id=company_id)
-        
+
         if not available_tests:
             await callback.message.edit_text(
-                "🗺️ <b>Тесты траектории</b>\n\n"
-                "У тебя пока нет доступных тестов для прохождения.\n"
-                "Обратись к наставнику для получения доступа к тестам.",
-                parse_mode="HTML"
+                "Твой наставник пока не назначил тебе тесты 🥹\n\n"
+                "Как только он это сделает, ты сможешь приступить к ним. "
+                "Если хочешь ускорить процесс — свяжись с наставником напрямую",
+                parse_mode="HTML",
+                reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                    [InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]
+                ])
             )
             await callback.answer()
             return
@@ -2296,13 +2305,16 @@ async def process_trajectory_tests_shortcut(callback: CallbackQuery, state: FSMC
         return
     
     available_tests = await get_trainee_available_tests(session, user.id, company_id=company_id)
-    
+
     if not available_tests:
         await callback.message.edit_text(
-            "🗺️ <b>Тесты траектории</b>\n\n"
-            "У тебя пока нет доступных тестов для прохождения.\n"
-            "Обратись к наставнику для получения доступа к тестам.",
-            parse_mode="HTML"
+            "Твой наставник пока не назначил тебе тесты 🥹\n\n"
+            "Как только он это сделает, ты сможешь приступить к ним. "
+            "Если хочешь ускорить процесс — свяжись с наставником напрямую",
+            parse_mode="HTML",
+            reply_markup=InlineKeyboardMarkup(inline_keyboard=[
+                [InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]
+            ])
         )
         await callback.answer()
         return

--- a/handlers/training/mentorship.py
+++ b/handlers/training/mentorship.py
@@ -241,39 +241,22 @@ async def cmd_mentor_trainees(message: Message, state: FSMContext, session: Asyn
 
 @router.callback_query(F.data == "mentor_panel")
 async def callback_mentor_panel(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
-    """Обработчик инлайн-кнопки 'Панель наставника 🎓' — инструкция + навигация (по Figma 11.1-11.6)"""
+    """Обработчик инлайн-кнопки 'Панель наставника 🎓' — навигация (по Figma 11.1-11.6)"""
     user = await get_user_by_tg_id(session, callback.from_user.id)
     if not user:
         await callback.answer("❌ Не зарегистрирован", show_alert=True)
         return
 
-    instruction_text = (
-        "<b>Инструкция для наставника</b>\n\n"
-        "<b>Напиши новому стажеру:</b>\n"
-        "👋 При появлении нового стажера у тебя есть возможность "
-        "сразу посмотреть его контактные данные для связи\n\n"
-        "<b>Назначение траектории:</b>\n"
-        "📖 Обязательно назначь обучающую траекторию — это пошаговый "
-        "маршрут с закреплёнными материалами и тестами, чтобы обучение "
-        "было последовательным\n\n"
-        "<b>Управление доступом:</b>\n"
-        "🔓 Открывай доступ к этапам траектории постепенно. Так стажер "
-        "не перегрузится сразу, будет идти по шагам и лучше усваивать материал\n\n"
-        "<b>Отслеживание прогресса:</b>\n"
-        "📈 Следи за прогрессом: выбирая стажера, можешь видеть, "
-        "на каком он этапе и как успешно проходит каждый тест\n\n"
-        "<b>Аттестация:</b>\n"
-        "🎓 Для завершения стажировки стажеру нужно сдать аттестацию. "
-        "Ты можешь назначить ее только после успешного прохождения всех тестов."
-    )
+    panel_text = "<b>Панель наставника 🎓</b>"
 
     keyboard = InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="Мои стажеры", callback_data="mentor_my_trainees")],
         [InlineKeyboardButton(text="Назначить тест", callback_data="mentor_assign_test")],
+        [InlineKeyboardButton(text="Что делать?", callback_data="mentor_what_to_do")],
         [InlineKeyboardButton(text="☰ Главное меню", callback_data="main_menu")],
     ])
 
-    # Отправляем фото-баннер + инструкцию (по Figma 11.1-11.2)
+    # Отправляем фото-баннер (по Figma 11.1-11.2)
     photo_source = None
     if MENTOR_PANEL_IMAGE_FILE_ID:
         photo_source = MENTOR_PANEL_IMAGE_FILE_ID
@@ -283,38 +266,77 @@ async def callback_mentor_panel(callback: CallbackQuery, state: FSMContext, sess
         except Exception:
             pass
 
+    try:
+        await callback.message.delete()
+    except Exception:
+        pass
+
     if photo_source:
-        try:
-            await callback.message.delete()
-        except:
-            pass
         try:
             await callback.message.answer_photo(
                 photo=photo_source,
-                caption=instruction_text,
+                caption=panel_text,
                 parse_mode="HTML",
                 reply_markup=keyboard
             )
         except Exception:
-            # Фоллбэк — текст без фото
             await callback.message.answer(
-                instruction_text,
+                panel_text,
                 reply_markup=keyboard,
                 parse_mode="HTML"
             )
     else:
-        try:
-            await callback.message.delete()
-        except Exception:
-            pass
         await callback.message.answer(
-            instruction_text,
+            panel_text,
             reply_markup=keyboard,
             parse_mode="HTML"
         )
 
     await callback.answer()
     log_user_action(callback.from_user.id, callback.from_user.username, "opened_mentor_panel")
+
+
+@router.callback_query(F.data == "mentor_what_to_do")
+async def callback_mentor_what_to_do(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Обработчик кнопки 'Что делать?' — инструкция для наставника"""
+    instruction_text = (
+        "<b>Инструкция для наставника</b>\n\n"
+        "<b>1. Напиши новому стажеру:</b>\n"
+        "👋 При появлении нового стажера у тебя есть возможность "
+        "сразу посмотреть его контактные данные для связи\n\n"
+        "<b>2. Назначение траектории:</b>\n"
+        "📖 Обязательно назначь обучающую траекторию — это пошаговый "
+        "маршрут с закреплёнными материалами и тестами, чтобы обучение "
+        "было последовательным\n\n"
+        "<b>3. Управление доступом:</b>\n"
+        "🔓 Открывай доступ к этапам траектории постепенно. Так стажер "
+        "не перегрузится сразу, будет идти по шагам и лучше усваивать материал\n\n"
+        "<b>4. Отслеживание прогресса:</b>\n"
+        "📈 Следи за прогрессом: выбирая стажера, можешь видеть, "
+        "на каком он этапе и как успешно проходит каждый тест\n\n"
+        "<b>5. Аттестация:</b>\n"
+        "🎓 Для завершения стажировки стажеру нужно сдать аттестацию. "
+        "Ты можешь назначить ее только после успешного прохождения всех тестов."
+    )
+
+    keyboard = InlineKeyboardMarkup(inline_keyboard=[
+        [InlineKeyboardButton(text="← назад", callback_data="mentor_panel")],
+        [InlineKeyboardButton(text="☰ Главное меню", callback_data="main_menu")],
+    ])
+
+    try:
+        await callback.message.delete()
+    except Exception:
+        pass
+
+    await callback.message.answer(
+        instruction_text,
+        reply_markup=keyboard,
+        parse_mode="HTML"
+    )
+
+    await callback.answer()
+    log_user_action(callback.from_user.id, callback.from_user.username, "opened_mentor_instructions")
 
 
 @router.callback_query(F.data == "mentor_my_trainees")
@@ -2205,7 +2227,7 @@ def generate_trajectory_progress_for_mentor(trainee_path, stages_progress, test_
     if not trainee_path:
         return "📖 <b>Траектория:</b> не выбрано"
 
-    progress = f"______________________________\n\n📖 <b>Траектория:</b> {trainee_path.learning_path.name if trainee_path.learning_path else 'Не указано'}\n\n"
+    progress = f"📖 <b>Траектория:</b> {trainee_path.learning_path.name if trainee_path.learning_path else 'Не указано'}\n\n"
 
     test_results_dict = {}
     if test_results:
@@ -2255,8 +2277,6 @@ def generate_trajectory_progress_for_mentor(trainee_path, stages_progress, test_
             progress += "\n👉 <b>Этап завершен!</b>\n"
         elif stage_progress.is_opened and total_tests > 0:
             progress += f"\n👉 <b>Пройдено:</b> {passed_tests}/{total_tests} тестов\n"
-
-        progress += "______________________________\n\n"
 
     # Аттестация
     if trainee_path.learning_path.attestation:
@@ -2270,7 +2290,7 @@ async def generate_trajectory_progress_with_attestation_status(session, trainee_
     if not trainee_path:
         return "📖 <b>Траектория:</b> не выбрано"
 
-    progress = f"______________________________\n\n📖 <b>Траектория:</b> {trainee_path.learning_path.name if trainee_path.learning_path else 'Не указано'}\n\n"
+    progress = f"📖 <b>Траектория:</b> {trainee_path.learning_path.name if trainee_path.learning_path else 'Не указано'}\n\n"
 
     test_results_dict = {}
     if test_results:
@@ -2320,8 +2340,6 @@ async def generate_trajectory_progress_with_attestation_status(session, trainee_
             progress += "\n👉 <b>Этап завершен!</b>\n"
         elif stage_progress.is_opened and total_tests > 0:
             progress += f"\n👉 <b>Пройдено:</b> {passed_tests}/{total_tests} тестов\n"
-
-        progress += "______________________________\n\n"
 
     # Аттестация с правильным статусом
     if trainee_path.learning_path.attestation:
@@ -4355,27 +4373,13 @@ async def update_stages_management_interface(callback: CallbackQuery, session: A
                 ])
 
         trainee = await get_user_by_id(session, trainee_id)
-        
-        # Вычисляем количество дней в статусе стажера
-        days_as_trainee = (moscow_now() - trainee.role_assigned_date).days
-        days_word = get_days_word(days_as_trainee)
-        
+
         # Получаем результаты тестов для правильной индикации
         test_results = await get_user_test_results(session, trainee_id, company_id=trainee.company_id)
-        
-        # Формируем полную информацию согласно ТЗ шаг 6
-        header_info = (
-            f"🦸🏻‍♂️<b>Стажер:</b> {trainee.full_name}\n\n"
-            f"<b>Телефон:</b> {trainee.phone_number}\n"
-            f"<b>В статусе стажера:</b> {days_as_trainee} {days_word}\n"
-            f"<b>Объект стажировки:</b> {trainee.internship_object.name if trainee.internship_object else 'Не указан'}\n"
-            f"<b>Объект работы:</b> {trainee.work_object.name if trainee.work_object else 'Не указан'}\n\n"
-            "━━━━━━━━━━━━\n\n"
-        )
-        
-        # Добавляем полную траекторию согласно ТЗ
+
+        # Формируем сообщение — сразу траектория без блока данных стажёра
         trajectory_progress = await generate_trajectory_progress_with_attestation_status(session, trainee_path, stages_progress, test_results)
-        header_info += trajectory_progress + "\n"
+        header_info = trajectory_progress + "\n"
         header_info += "🟡 <b>Какой этап необходимо открыть стажеру?</b>"
 
         # Добавляем кнопку "Назад" к выбору траектории

--- a/handlers/training/trainee_trajectory.py
+++ b/handlers/training/trainee_trajectory.py
@@ -465,7 +465,7 @@ async def callback_select_session(callback: CallbackQuery, state: FSMContext, se
             for i, test in enumerate(tests, 1):
                 keyboard_buttons.append([
                     InlineKeyboardButton(
-                        text=f"Тест {i}",
+                        text=test.name,
                         callback_data=f"take_test:{session_id}:{test.id}"
                     )
                 ])
@@ -600,7 +600,7 @@ async def callback_back_to_session(callback: CallbackQuery, state: FSMContext, s
             for i, test in enumerate(tests, 1):
                 keyboard_buttons.append([
                     InlineKeyboardButton(
-                        text=f"Тест {i}",
+                        text=test.name,
                         callback_data=f"take_test:{session_id}:{test.id}"
                     )
                 ])

--- a/keyboards/keyboards.py
+++ b/keyboards/keyboards.py
@@ -10,7 +10,7 @@ MAIN_MENU_TEXTS = {
     "Помощь ❓",
     "Помощь❓",
     "База знаний 📁️",
-    "База знаний 📁",
+    "База знаний 📒",
     "Мои тесты 📋",
     "Мои тесты 🗒",
     "Мои тесты 📁",  # старая версия или опечатка
@@ -154,7 +154,7 @@ def get_mentor_inline_menu() -> InlineKeyboardMarkup:
     """Инлайн-клавиатура главного меню наставника (по Figma)"""
     return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="Мой профиль 🦸🏻‍♂️", callback_data="mentor_profile")],
-        [InlineKeyboardButton(text="База знаний 📁", callback_data="mentor_knowledge_base")],
+        [InlineKeyboardButton(text="База знаний 📒", callback_data="mentor_knowledge_base")],
         [InlineKeyboardButton(text="Мои тесты 🗒", callback_data="mentor_my_tests")],
         [InlineKeyboardButton(text="Панель наставника 🎓", callback_data="mentor_panel")],
         [InlineKeyboardButton(text="Помощь ❓", callback_data="mentor_help")],
@@ -1106,7 +1106,7 @@ def format_help_message(role_name: str) -> str:
 <b>Основные функции:</b>
 • <b>Панель наставника 🎓</b> — список стажеров, управление траекториями и этапами
 • <b>Мои тесты 🗒</b> — пройти тесты, назначенные рекрутером через рассылку
-• <b>База знаний 📁</b> — корпоративные материалы
+• <b>База знаний 📒</b> — корпоративные материалы
 
 <b>Возможности:</b>
 • Назначение траекторий обучения своим стажерам
@@ -2408,7 +2408,7 @@ def get_session_tests_keyboard(tests: list, session_id: int, stage_id: int) -> I
     # Список тестов в сессии (кнопки для редактирования)
     for i, test in enumerate(tests, 1):
         keyboard.append([InlineKeyboardButton(
-            text=f"Тест {i}",
+            text=test.name,
             callback_data=f"edit_test:{test.id}:{session_id}"
         )])
     

--- a/tests/e2e/test_stage_management.py
+++ b/tests/e2e/test_stage_management.py
@@ -2,7 +2,7 @@
 E2E Сценарий 4: Закрытие этапа — согласованность UI и access.
 
 Проверяет, что:
-- Открытие этапа → стажёр видит ♻️
+- Открытие этапа → стажёр видит ⏳
 - Прохождение теста → стажёр видит ✅
 - Закрытие этапа → стажёр видит ❌, но данные не потеряны
 - Наставник видит тест как пройденный даже в закрытом этапе
@@ -43,7 +43,7 @@ class TestScenario4_StageOpenCloseConsistency:
     async def test_step2_trainee_sees_open_stage(
         self, trainee1: BotClient, shared_state: dict
     ):
-        """Стажёр 1 видит этап 1 как открытый (♻️ или ✅)."""
+        """Стажёр 1 видит этап 1 как открытый (⏳ или ✅)."""
         await wait_between_actions()
 
         resp = await trainee1.send_and_wait(
@@ -52,11 +52,11 @@ class TestScenario4_StageOpenCloseConsistency:
 
         text = resp.text or ""
 
-        # Этап 1 должен быть открыт (♻️) или пройден (✅), но НЕ закрыт (❌)
+        # Этап 1 должен быть открыт (⏳) или пройден (✅), но НЕ закрыт (❌)
         # Тест 1 уже пройден, поэтому может быть ✅
-        has_open_or_passed = "♻️" in text or "✅" in text
+        has_open_or_passed = "⏳" in text or "✅" in text
         assert has_open_or_passed, (
-            f"Stage 1 should be open (♻️) or passed (✅) after reopening. Got: {text[:500]}"
+            f"Stage 1 should be open (⏳) or passed (✅) after reopening. Got: {text[:500]}"
         )
 
         shared_state["stage1_open_text"] = text

--- a/tests/unit/utils/test_test_progress_formatters.py
+++ b/tests/unit/utils/test_test_progress_formatters.py
@@ -23,7 +23,7 @@ class TestGetTestStatusIcon:
     def test_not_passed_stage_open_returns_available(self):
         """Если тест не пройден и этап открыт - доступен"""
         icon = get_test_status_icon(is_passed=False, is_stage_opened=True)
-        assert icon == "♻️"
+        assert icon == "⏳"
 
     def test_not_passed_stage_closed_returns_closed(self):
         """Если тест не пройден и этап закрыт - закрытый"""

--- a/utils/test_progress_formatters.py
+++ b/utils/test_progress_formatters.py
@@ -19,7 +19,7 @@ from typing import Optional
 
 # Константы для иконок статуса теста
 TEST_ICON_PASSED = "✅"
-TEST_ICON_AVAILABLE = "♻️"
+TEST_ICON_AVAILABLE = "⏳"
 TEST_ICON_CLOSED = "❌"
 
 
@@ -36,7 +36,7 @@ def get_test_status_icon(is_passed: bool, is_stage_opened: bool) -> str:
 
     Логика (единая для всего приложения):
         - Пройден И этап открыт: ✅
-        - Не пройден И этап открыт: ♻️
+        - Не пройден И этап открыт: ⏳
         - Этап закрыт: ❌
     """
     if is_passed and is_stage_opened:


### PR DESCRIPTION
## Summary
- Restructured `handlers/` into domain-based subpackages (core, company, users, tests, training, management, knowledge)
- Redesigned trainee trajectory UI with inline buttons matching Figma designs (13.1-13.4, 17.1-17.5, 18.1)
- Added mentor panel with inline navigation and trainee management (Figma 7.1-7.4, 11.x)
- Fixed `check_test_access` bug denying legitimate test access
- Fixed trajectory reassignment deleting test results
- Converted mentor and trainee menus to inline keyboards
- Added banner images for mentor and trainee screens
- Switched entire project to Moscow timezone (UTC+3)
- UI text/emoji improvements per client feedback

## Test plan
- [x] 56/56 e2e tests pass
- [x] 40/40 unit tests pass