### PR TITLE
feat: exam system — create, assign, conduct exams

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ COPY . .
 
 ENV PYTHONPATH=/app/src
 
-RUN mkdir -p /app/logs
+RUN mkdir -p /app/logs && chmod +x entrypoint.sh
 
-CMD ["python", "-m", "bot"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running alembic migrations..."
+alembic upgrade head
+
+echo "Starting bot..."
+exec python -m bot

--- a/src/bot/__main__.py
+++ b/src/bot/__main__.py
@@ -12,6 +12,7 @@ from bot.database.db import init_db
 from bot.handlers import fallback
 from bot.handlers.company import company, groups, objects
 from bot.handlers.core import auth, common, registration
+from bot.handlers.exams import exam_assignment, exam_conducting, exam_menu
 from bot.handlers.knowledge import knowledge_base
 from bot.handlers.management import employee_transition, manager_attestation, manager_menu
 from bot.handlers.tests import broadcast, test_taking, tests
@@ -50,6 +51,9 @@ dp.include_router(mentorship.router)
 dp.include_router(mentor_assignment.router)  # Назначение наставников
 dp.include_router(manager_attestation.router)  # Проведение аттестаций руководителями
 dp.include_router(manager_menu.router)  # Меню руководителя
+dp.include_router(exam_menu.router)  # Экзамены: меню, создание, карточка
+dp.include_router(exam_assignment.router)  # Экзамены: назначение
+dp.include_router(exam_conducting.router)  # Экзамены: проведение, сдача
 dp.include_router(test_taking.router)  # Прохождение тестов (должен быть раньше trainee_trajectory)
 dp.include_router(trainee_trajectory.router)  # Прохождение траекторий стажерами
 dp.include_router(groups.router)

--- a/src/bot/database/db.py
+++ b/src/bot/database/db.py
@@ -4928,6 +4928,16 @@ async def migrate_new_tables():
             except Exception as e:
                 logger.info(f"tests.material_type уже существует или ошибка: {e}")
 
+            # Миграция: добавляем поле assessment_type для аттестаций/экзаменов
+            try:
+                await conn.execute(
+                    text(
+                        "ALTER TABLE attestations ADD COLUMN IF NOT EXISTS assessment_type VARCHAR DEFAULT 'attestation' NOT NULL"
+                    )
+                )
+            except Exception as e:
+                logger.info(f"attestations.assessment_type уже существует или ошибка: {e}")
+
         # logger.info("✅ Миграция новых таблиц для траекторий ЗАВЕРШЕНА УСПЕШНО")  # Миграции выполнены
     except Exception as e:
         logger.error(f"❌ ОШИБКА МИГРАЦИИ новых таблиц: {type(e).__name__}: {e}")

--- a/src/bot/database/models.py
+++ b/src/bot/database/models.py
@@ -478,6 +478,7 @@ class Attestation(Base):
     created_date = Column(DateTime, default=moscow_now)
     is_active = Column(Boolean, default=True)
     company_id = Column(Integer, ForeignKey("companies.id"), nullable=True, index=True)  # Компания аттестации
+    assessment_type = Column(String, nullable=False, default="attestation")  # 'attestation' или 'exam'
 
     # Связи
     created_by = relationship("User")
@@ -493,6 +494,7 @@ class Attestation(Base):
     __table_args__ = (
         Index("idx_attestation_is_active", "is_active"),
         Index("idx_attestation_company_active", "company_id", "is_active"),
+        Index("idx_attestation_type", "assessment_type"),
     )
 
     def __repr__(self):

--- a/src/bot/handlers/exams/__init__.py
+++ b/src/bot/handlers/exams/__init__.py
@@ -1,0 +1,9 @@
+from bot.handlers.exams.exam_assignment import router as exam_assignment_router
+from bot.handlers.exams.exam_conducting import router as exam_conducting_router
+from bot.handlers.exams.exam_menu import router as exam_menu_router
+
+__all__ = [
+    "exam_menu_router",
+    "exam_assignment_router",
+    "exam_conducting_router",
+]

--- a/src/bot/handlers/exams/exam_assignment.py
+++ b/src/bot/handlers/exams/exam_assignment.py
@@ -1,0 +1,543 @@
+"""
+Обработчики назначения экзаменов: выбор экзаменатора, фильтрация сдающих, назначение.
+"""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.database.db import get_all_groups, get_all_objects, get_user_by_id, get_user_by_tg_id
+from bot.keyboards.keyboards import (
+    exam_filters,
+    get_exam_examiner_list_keyboard,
+    is_main_menu_text,
+)
+from bot.repositories import AssessmentAssignmentRepository, AssessmentRepository
+from bot.states.states import ExamStates
+from bot.utils.logger import log_user_action, log_user_error
+
+router = Router()
+
+
+# ================== Flow E: Назначение экзамена ==================
+
+
+@router.callback_query(F.data.startswith("exam_assign:"), ExamStates.viewing_exam)
+async def callback_exam_assign(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Начало назначения экзамена — показываем список экзаменаторов"""
+    try:
+        await callback.answer()
+
+        exam_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+        if not exam:
+            await callback.message.edit_text("Экзамен не найден")
+            return
+
+        examiners = await AssessmentAssignmentRepository(session).get_examiners(company_id=company_id)
+
+        if not examiners:
+            await callback.message.edit_text(
+                "❌ Нет доступных экзаменаторов (руководителей, сотрудников или рекрутеров).",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[[InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_menu")]]
+                ),
+            )
+            return
+
+        text = (
+            f"🔖<b>РЕДАКТОР Экзаменов</b>\n"
+            f"📋 <b>Экзамен:</b> {exam.name}\n"
+            f"📋 <b>Всего вопросов:</b> {len(exam.questions)}\n\n"
+            "👨‍⚖️ <b>Экзаменатор:</b>\nВыбери экзаменатора из списка"
+        )
+
+        await state.update_data(assign_exam_id=exam_id)
+        await callback.message.edit_text(
+            text, parse_mode="HTML", reply_markup=get_exam_examiner_list_keyboard(examiners)
+        )
+        await state.set_state(ExamStates.selecting_examiner)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_assign_error", str(e))
+
+
+@router.callback_query(F.data == "exam_back_to_card")
+async def callback_exam_back_to_card(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Возврат к карточке экзамена"""
+    try:
+        await callback.answer()
+        data = await state.get_data()
+        exam_id = data.get("assign_exam_id") or data.get("current_exam_id")
+        if exam_id:
+            # Имитируем просмотр карточки
+            callback.data = f"exam_view:{exam_id}"
+            await state.set_state(ExamStates.main_menu)
+            from bot.handlers.exams.exam_menu import callback_exam_view
+
+            await callback_exam_view(callback, state, session)
+        else:
+            from bot.handlers.exams.exam_menu import show_exam_menu
+
+            await show_exam_menu(callback, state, session)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_back_to_card_error", str(e))
+
+
+@router.callback_query(F.data.startswith("exam_examiner:"), ExamStates.selecting_examiner)
+async def callback_exam_examiner_selected(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Выбран экзаменатор — показываем фильтры для сдающего"""
+    try:
+        await callback.answer()
+
+        examiner_id = int(callback.data.split(":")[1])
+        examiner = await get_user_by_id(session, examiner_id)
+        if not examiner:
+            await callback.message.edit_text("Экзаменатор не найден")
+            return
+
+        data = await state.get_data()
+        company_id = data.get("company_id")
+        exam_id = data.get("assign_exam_id")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+
+        await state.update_data(assign_examiner_id=examiner_id, assign_examiner_name=examiner.full_name)
+
+        groups = await get_all_groups(session, company_id=company_id)
+        objects = await get_all_objects(session, company_id=company_id)
+
+        text = (
+            f"🔖<b>РЕДАКТОР Экзаменов</b>\n"
+            f"📋 <b>Экзамен:</b> {exam.name}\n"
+            f"📋 <b>Всего вопросов:</b> {len(exam.questions)}\n"
+            f"👨‍⚖️ <b>Экзаменатор:</b> {examiner.full_name}\n\n"
+            "👤 <b>Сдающий:</b>\nВыберите способ поиска сдающего"
+        )
+
+        await callback.message.edit_text(
+            text,
+            parse_mode="HTML",
+            reply_markup=exam_filters.filter_menu(groups, objects),
+        )
+        await state.set_state(ExamStates.selecting_examinee_filter)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_examiner_selected_error", str(e))
+
+
+# ================== Фильтрация сдающих ==================
+
+
+@router.callback_query(F.data == exam_filters.cb_back)
+async def callback_exam_back_to_filters(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Возврат к фильтрам сдающих"""
+    try:
+        await callback.answer()
+        data = await state.get_data()
+        company_id = data.get("company_id")
+        exam_id = data.get("assign_exam_id")
+        examiner_name = data.get("assign_examiner_name", "")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+        groups = await get_all_groups(session, company_id=company_id)
+        objects = await get_all_objects(session, company_id=company_id)
+
+        text = (
+            f"🔖<b>РЕДАКТОР Экзаменов</b>\n"
+            f"📋 <b>Экзамен:</b> {exam.name if exam else '?'}\n"
+            f"👨‍⚖️ <b>Экзаменатор:</b> {examiner_name}\n\n"
+            "👤 <b>Сдающий:</b>\nВыберите способ поиска сдающего"
+        )
+
+        await callback.message.edit_text(
+            text,
+            parse_mode="HTML",
+            reply_markup=exam_filters.filter_menu(groups, objects),
+        )
+        await state.set_state(ExamStates.selecting_examinee_filter)
+
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_back_to_filters_error", str(e))
+
+
+@router.callback_query(F.data == exam_filters.cb_all, ExamStates.selecting_examinee_filter)
+async def callback_exam_filter_all(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Фильтр: все пользователи"""
+    try:
+        await callback.answer()
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        users = await AssessmentAssignmentRepository(session).get_users_for_exam_assignment(
+            company_id, filter_type="all"
+        )
+        await _show_examinee_list(callback, state, users)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_filter_all_error", str(e))
+
+
+@router.callback_query(F.data == exam_filters.cb_groups, ExamStates.selecting_examinee_filter)
+async def callback_exam_filter_groups(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Фильтр: по группам — показать список групп"""
+    try:
+        await callback.answer()
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        groups = await get_all_groups(session, company_id=company_id)
+
+        await callback.message.edit_text(
+            "🗂️ <b>Выбери группу:</b>",
+            parse_mode="HTML",
+            reply_markup=exam_filters.group_list(groups),
+        )
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_filter_groups_error", str(e))
+
+
+@router.callback_query(F.data.startswith(exam_filters.prefix + "_group:"))
+async def callback_exam_group_selected(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Выбрана группа — показать пользователей группы"""
+    try:
+        await callback.answer()
+        group_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        users = await AssessmentAssignmentRepository(session).get_users_for_exam_assignment(
+            company_id, filter_type="group", filter_id=group_id
+        )
+        await state.update_data(exam_filter_type="group", exam_filter_id=group_id)
+        await _show_examinee_list(callback, state, users)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_group_selected_error", str(e))
+
+
+@router.callback_query(F.data == exam_filters.cb_objects, ExamStates.selecting_examinee_filter)
+async def callback_exam_filter_objects(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Фильтр: по объектам — показать список объектов"""
+    try:
+        await callback.answer()
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        objects = await get_all_objects(session, company_id=company_id)
+
+        await callback.message.edit_text(
+            "📍 <b>Выбери объект:</b>",
+            parse_mode="HTML",
+            reply_markup=exam_filters.object_list(objects),
+        )
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_filter_objects_error", str(e))
+
+
+@router.callback_query(F.data.startswith(exam_filters.prefix + "_object:"))
+async def callback_exam_object_selected(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Выбран объект — показать пользователей объекта"""
+    try:
+        await callback.answer()
+        object_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        users = await AssessmentAssignmentRepository(session).get_users_for_exam_assignment(
+            company_id, filter_type="object", filter_id=object_id
+        )
+        await state.update_data(exam_filter_type="object", exam_filter_id=object_id)
+        await _show_examinee_list(callback, state, users)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_object_selected_error", str(e))
+
+
+@router.callback_query(F.data == exam_filters.cb_search, ExamStates.selecting_examinee_filter)
+async def callback_exam_filter_search(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Фильтр: поиск по ФИО"""
+    try:
+        await callback.answer()
+
+        await callback.message.edit_text(
+            "🟣 <b>Поиск по ФИО</b>\n\nВведи имя или часть имени:",
+            parse_mode="HTML",
+        )
+        await state.set_state(ExamStates.searching_examinee_by_name)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_filter_search_error", str(e))
+
+
+@router.message(ExamStates.searching_examinee_by_name)
+async def process_exam_search_query(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработка поискового запроса по ФИО"""
+    try:
+        query = message.text.strip()
+
+        if is_main_menu_text(query):
+            return
+
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        users = await AssessmentAssignmentRepository(session).get_users_for_exam_assignment(
+            company_id, filter_type="search", search_query=query
+        )
+
+        if not users:
+            await message.answer(
+                f"❌ По запросу «{query}» никого не найдено. Попробуй другое имя:",
+            )
+            return
+
+        # Сохраняем список для пагинации
+        await state.update_data(
+            exam_filtered_users=[u.id for u in users],
+            exam_filter_type="search",
+        )
+
+        keyboard = exam_filters.user_list(users)
+        await message.answer(
+            f"🔍 Найдено: {len(users)}\nВыбери сдающего:",
+            reply_markup=keyboard,
+        )
+        await state.set_state(ExamStates.selecting_examinee)
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при поиске")
+        log_user_error(message.from_user.id, "process_exam_search_error", str(e))
+
+
+async def _show_examinee_list(callback: CallbackQuery, state: FSMContext, users: list):
+    """Показ списка сдающих"""
+    if not users:
+        await callback.message.edit_text(
+            "❌ Пользователи не найдены.",
+            reply_markup=InlineKeyboardMarkup(
+                inline_keyboard=[[InlineKeyboardButton(text="🔙 Назад", callback_data=exam_filters.cb_back)]]
+            ),
+        )
+        return
+
+    await state.update_data(exam_filtered_users=[u.id for u in users])
+
+    keyboard = exam_filters.user_list(users)
+    await callback.message.edit_text(
+        f"👤 Найдено: {len(users)}\nВыбери сдающего:",
+        reply_markup=keyboard,
+    )
+    await state.set_state(ExamStates.selecting_examinee)
+
+
+# ================== Пагинация сдающих ==================
+
+
+@router.callback_query(F.data.startswith(exam_filters.prefix + "_upage:"), ExamStates.selecting_examinee)
+async def callback_exam_examinee_page(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Пагинация списка сдающих"""
+    try:
+        await callback.answer()
+        page = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        user_ids = data.get("exam_filtered_users", [])
+
+        # Загружаем пользователей
+        users = []
+        for uid in user_ids:
+            u = await get_user_by_id(session, uid)
+            if u:
+                users.append(u)
+
+        keyboard = exam_filters.user_list(users, page=page)
+        await callback.message.edit_text(
+            f"👤 Найдено: {len(users)}\nВыбери сдающего:",
+            reply_markup=keyboard,
+        )
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_examinee_page_error", str(e))
+
+
+# ================== Карточка сдающего + назначение ==================
+
+
+@router.callback_query(F.data.startswith(exam_filters.prefix + "_user:"), ExamStates.selecting_examinee)
+async def callback_exam_examinee_selected(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Выбран сдающий — показываем его карточку"""
+    try:
+        await callback.answer()
+
+        examinee_id = int(callback.data.split(":")[1])
+        examinee = await get_user_by_id(session, examinee_id)
+        if not examinee:
+            await callback.message.edit_text("Пользователь не найден")
+            return
+
+        data = await state.get_data()
+        exam_id = data.get("assign_exam_id")
+        examiner_name = data.get("assign_examiner_name", "")
+        company_id = data.get("company_id")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+
+        role_name = examinee.roles[0].name if examinee.roles else "Без роли"
+        group_name = examinee.groups[0].name if examinee.groups else "Не указана"
+
+        text = (
+            f"📋 <b>Экзамен:</b> {exam.name if exam else '?'}\n"
+            f"👨‍⚖️ <b>Экзаменатор:</b> {examiner_name}\n\n"
+            f"👤 <b>Карточка пользователя</b>\n"
+            f"📞 <b>Номер:</b> {examinee.phone_number}\n"
+            f"📅 <b>Дата регистрации:</b> {examinee.registration_date.strftime('%d.%m.%Y') if examinee.registration_date else '-'}\n"
+            f"🔵 <b>Статус:</b> {'Активен' if examinee.is_activated else 'Не активирован'}\n"
+            f"🗂️ <b>Группа:</b> {group_name}\n"
+            f"👑 <b>Роль:</b> {role_name}\n"
+            f"📍 <b>Объект работы:</b> {examinee.work_object.name if examinee.work_object else 'Не указан'}"
+        )
+
+        await state.update_data(assign_examinee_id=examinee_id, assign_examinee_name=examinee.full_name)
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="📌 Назначить экзамен", callback_data="exam_confirm_assign")],
+                [InlineKeyboardButton(text="🔙 Назад", callback_data=exam_filters.cb_back)],
+            ]
+        )
+
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+        await state.set_state(ExamStates.viewing_examinee_card)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_examinee_selected_error", str(e))
+
+
+@router.callback_query(F.data == "exam_confirm_assign", ExamStates.viewing_examinee_card)
+async def callback_exam_confirm_assign(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Подтверждение назначения экзамена"""
+    try:
+        await callback.answer()
+
+        data = await state.get_data()
+        exam_id = data.get("assign_exam_id")
+        examiner_id = data.get("assign_examiner_id")
+        examinee_id = data.get("assign_examinee_id")
+        examiner_name = data.get("assign_examiner_name", "")
+        examinee_name = data.get("assign_examinee_name", "")
+        company_id = data.get("company_id")
+
+        if not all([exam_id, examiner_id, examinee_id]):
+            await callback.message.edit_text("❌ Недостаточно данных для назначения")
+            return
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+
+        # Назначаем экзамен (используем тот же механизм что и аттестации)
+        assignment = await AssessmentAssignmentRepository(session).assign(
+            trainee_id=examinee_id,
+            manager_id=examiner_id,
+            attestation_id=exam_id,
+            assigned_by_id=user.id,
+            company_id=company_id,
+        )
+
+        if not assignment:
+            await callback.message.edit_text("❌ Ошибка при назначении экзамена")
+            return
+
+        await session.commit()
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+
+        text = (
+            "🔖<b>РЕДАКТОР Экзамена</b>🔖\n"
+            "✅ <b>ЭКЗАМЕН НАЗНАЧЕН</b> ✅\n\n"
+            f"📋 <b>Экзамен:</b> {exam.name if exam else '?'}\n"
+            f"📋 <b>Всего вопросов:</b> {len(exam.questions) if exam else 0}\n"
+            f"👨‍⚖️ <b>Экзаменатор:</b> {examiner_name}\n"
+            f"💛 <b>Сдающий:</b> {examinee_name}\n\n"
+            "Уведомление об экзамене направлено экзаменатору и сдающему 📩"
+        )
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]]
+        )
+
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+
+        # Отправляем уведомления
+        await _send_exam_notifications(
+            session,
+            callback.message.bot,
+            exam,
+            examiner_id,
+            examinee_id,
+            examiner_name,
+            examinee_name,
+        )
+
+        await state.clear()
+        # Восстанавливаем company_id
+        await state.update_data(company_id=company_id)
+
+        log_user_action(
+            callback.from_user.id,
+            "exam_assigned",
+            f"Экзамен {exam.name if exam else exam_id} назначен: экзаменатор={examiner_name}, сдающий={examinee_name}",
+        )
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка при назначении экзамена")
+        log_user_error(callback.from_user.id, "exam_confirm_assign_error", str(e))
+
+
+# ================== Уведомления ==================
+
+
+async def _send_exam_notifications(
+    session: AsyncSession,
+    bot,
+    exam,
+    examiner_id: int,
+    examinee_id: int,
+    examiner_name: str,
+    examinee_name: str,
+):
+    """Отправка уведомлений экзаменатору и сдающему"""
+    try:
+        examiner = await get_user_by_id(session, examiner_id)
+        examinee = await get_user_by_id(session, examinee_id)
+
+        # Уведомление экзаменатору
+        if examiner:
+            examiner_text = (
+                "📝 <b>Тебе назначен экзамен для проведения</b>\n\n"
+                f"📋 <b>Экзамен:</b> {exam.name}\n"
+                f"💛 <b>Сдающий:</b> {examinee_name}\n"
+                f"📍 <b>Объект работы:</b> {examinee.work_object.name if examinee and examinee.work_object else 'Не указан'}\n\n"
+                "Свяжись со сдающим, чтобы подтвердить все детали"
+            )
+            try:
+                await bot.send_message(chat_id=examiner.tg_id, text=examiner_text, parse_mode="HTML")
+            except Exception as e:
+                log_user_error(0, "exam_notification_examiner_error", str(e))
+
+        # Уведомление сдающему (Flow G)
+        if examinee:
+            examinee_text = (
+                f"📝 <b>Тебе назначен Экзамен: {exam.name}</b>\n\n"
+                f"👨‍⚖️ <b>Экзаменатор:</b> {examiner_name}\n"
+                f"🏪 <b>Объект стажировки:</b> {examinee.internship_object.name if examinee.internship_object else 'Не указан'}\n"
+                f"📍 <b>Объект работы:</b> {examinee.work_object.name if examinee.work_object else 'Не указан'}\n\n"
+                "Свяжись с руководителем, чтобы точно подтвердить все детали"
+            )
+            try:
+                await bot.send_message(chat_id=examinee.tg_id, text=examinee_text, parse_mode="HTML")
+            except Exception as e:
+                log_user_error(0, "exam_notification_examinee_error", str(e))
+
+    except Exception as e:
+        log_user_error(0, "send_exam_notifications_error", str(e))

--- a/src/bot/handlers/exams/exam_conducting.py
+++ b/src/bot/handlers/exams/exam_conducting.py
@@ -1,0 +1,474 @@
+"""
+Обработчики проведения экзаменов: список для экзаменатора, прохождение вопросов,
+результаты, список для сдающего.
+"""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, InlineKeyboardButton, InlineKeyboardMarkup, Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.database.db import get_user_by_tg_id
+from bot.keyboards.keyboards import is_main_menu_text
+from bot.repositories import AssessmentAssignmentRepository, AssessmentResultRepository
+from bot.states.states import ExamStates
+from bot.utils.logger import log_user_action, log_user_error
+
+router = Router()
+
+
+# ================== Flow F: Провести экзамен (экзаменатор) ==================
+
+
+@router.callback_query(F.data == "exam_conduct", ExamStates.main_menu)
+async def callback_exam_conduct(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Список назначенных экзаменов для экзаменатора"""
+    try:
+        await callback.answer()
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+        if not user:
+            await callback.message.edit_text("Ты не зарегистрирован в системе.")
+            return
+
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        assignments = await AssessmentAssignmentRepository(session).get_exam_assignments_for_examiner(
+            user.id, company_id=company_id
+        )
+
+        if not assignments:
+            await callback.message.edit_text(
+                "🔍<b>Экзамены 🔍</b>\n\n❌ Нет назначенных экзаменов для проведения.",
+                parse_mode="HTML",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[[InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_menu")]]
+                ),
+            )
+            return
+
+        # Формируем список сдающих
+        text = "🔍<b>Экзамены 🔍</b>\nСписок сотрудников, которые готовы пройти экзамен 👋\n\n"
+
+        keyboard = InlineKeyboardMarkup(inline_keyboard=[])
+
+        for assignment in assignments:
+            examinee = assignment.trainee
+            exam = assignment.attestation
+
+            text += (
+                f"── 🟢 <b>ФИО:</b> {examinee.full_name}\n"
+                f"   📊 <b>Экзамен:</b> {exam.name}\n"
+                f"   📍 <b>Объект работы:</b> {examinee.work_object.name if examinee.work_object else 'Не указан'}\n\n"
+            )
+
+            keyboard.inline_keyboard.append(
+                [
+                    InlineKeyboardButton(
+                        text=examinee.full_name,
+                        callback_data=f"exam_conduct_select:{assignment.id}",
+                    )
+                ]
+            )
+
+        text += "Выбери сотрудника на клавиатуре"
+        keyboard.inline_keyboard.append([InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_menu")])
+
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+        await state.set_state(ExamStates.selecting_examinee_for_exam)
+
+        log_user_action(user.tg_id, "exam_conduct_list", f"Открыт список для проведения: {len(assignments)} экзаменов")
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_conduct_error", str(e))
+
+
+@router.callback_query(F.data.startswith("exam_conduct_select:"), ExamStates.selecting_examinee_for_exam)
+async def callback_exam_conduct_select(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Выбран сдающий — карточка управления экзаменом"""
+    try:
+        await callback.answer()
+
+        assignment_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        assignment = await AssessmentAssignmentRepository(session).get_by_id(assignment_id, company_id=company_id)
+        if not assignment:
+            await callback.message.edit_text("Экзамен не найден")
+            return
+
+        examinee = assignment.trainee
+        exam = assignment.attestation
+
+        text = (
+            "🔍<b>Экзамен 🔍</b>\n"
+            "Управление экзаменом\n\n"
+            f"👤 <b>ФИО:</b> {examinee.full_name}\n"
+            f"📊 <b>Экзамен:</b> {exam.name}\n"
+            f"📍 <b>Объект стажировки:</b> {examinee.internship_object.name if examinee.internship_object else 'Не указан'}\n"
+            f"📍 <b>Объект работы:</b> {examinee.work_object.name if examinee.work_object else 'Не указан'}"
+        )
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text="🚀 Начать экзамен", callback_data=f"exam_start:{assignment_id}")],
+                [InlineKeyboardButton(text="🔙 Назад", callback_data="exam_conduct")],
+            ]
+        )
+
+        await state.update_data(exam_assignment_id=assignment_id)
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+        await state.set_state(ExamStates.viewing_exam_details)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_conduct_select_error", str(e))
+
+
+@router.callback_query(F.data == "exam_conduct", ExamStates.viewing_exam_details)
+async def callback_exam_back_to_conduct(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Возврат к списку экзаменов (из деталей)"""
+    await state.set_state(ExamStates.main_menu)
+    await callback_exam_conduct(callback, state, session)
+
+
+@router.callback_query(F.data.startswith("exam_start:"), ExamStates.viewing_exam_details)
+async def callback_exam_start(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Подтверждение старта экзамена"""
+    try:
+        await callback.answer()
+
+        assignment_id = int(callback.data.split(":")[1])
+
+        text = "🚀 <b>Начать экзамен?</b>"
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [
+                    InlineKeyboardButton(text="✅ Да", callback_data="exam_confirm_start"),
+                    InlineKeyboardButton(text="❌ Нет", callback_data=f"exam_conduct_select:{assignment_id}"),
+                ]
+            ]
+        )
+
+        await state.update_data(exam_assignment_id=assignment_id)
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_start_error", str(e))
+
+
+@router.callback_query(F.data == "exam_confirm_start", ExamStates.viewing_exam_details)
+async def callback_exam_confirm_start(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Подтверждение — начинаем прохождение вопросов"""
+    try:
+        await callback.answer()
+
+        data = await state.get_data()
+        assignment_id = data.get("exam_assignment_id")
+        company_id = data.get("company_id")
+
+        # Начинаем сессию
+        await AssessmentAssignmentRepository(session).start_session(assignment_id, company_id=company_id)
+
+        await state.update_data(exam_current_question=0, exam_answers=[])
+
+        # Показываем первый вопрос
+        await _show_exam_question(callback.message, state, session, is_callback=True)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка при начале экзамена")
+        log_user_error(callback.from_user.id, "exam_confirm_start_error", str(e))
+
+
+async def _show_exam_question(message, state: FSMContext, session: AsyncSession, is_callback: bool = False):
+    """Показ вопроса экзамена"""
+    try:
+        data = await state.get_data()
+        assignment_id = data.get("exam_assignment_id")
+        current_index = data.get("exam_current_question", 0)
+        company_id = data.get("company_id")
+
+        assignment = await AssessmentAssignmentRepository(session).get_by_id(assignment_id, company_id=company_id)
+        if not assignment:
+            await message.edit_text("Экзамен не найден") if is_callback else await message.answer("Экзамен не найден")
+            return
+
+        exam = assignment.attestation
+        questions = exam.questions
+
+        if current_index >= len(questions):
+            # Все вопросы пройдены
+            await _show_exam_results(message, state, session)
+            return
+
+        question = questions[current_index]
+
+        text = (
+            f"<b>Вопрос {current_index + 1}:</b>\n\n"
+            f"{question.question_text}\n\n"
+            f"🎯 <b>Максимальный балл:</b> {question.max_points:.1f}\n\n"
+            "💡 <b>Инструкция:</b> Задай вопрос сдающему, выслушай ответ и введи балл."
+        )
+
+        if is_callback:
+            await message.edit_text(text, parse_mode="HTML")
+        else:
+            await message.answer(text, parse_mode="HTML")
+
+        await state.set_state(ExamStates.waiting_for_exam_score)
+
+    except Exception as e:
+        log_user_error(0, "show_exam_question_error", str(e))
+
+
+@router.message(ExamStates.waiting_for_exam_score)
+async def process_exam_score(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработка ввода балла за вопрос экзамена"""
+    try:
+        score_text = message.text.strip()
+
+        if is_main_menu_text(score_text):
+            data = await state.get_data()
+            company_id = data.get("company_id")
+            await state.clear()
+            await state.update_data(company_id=company_id)
+            return
+
+        try:
+            score = float(score_text)
+        except ValueError:
+            await message.answer("❌ Введи корректный балл (число)")
+            return
+
+        data = await state.get_data()
+        assignment_id = data.get("exam_assignment_id")
+        current_index = data.get("exam_current_question", 0)
+        answers = data.get("exam_answers", [])
+        company_id = data.get("company_id")
+
+        assignment = await AssessmentAssignmentRepository(session).get_by_id(assignment_id, company_id=company_id)
+        exam = assignment.attestation
+        questions = exam.questions
+
+        if current_index >= len(questions):
+            await message.answer("Ошибка: неверный индекс вопроса")
+            return
+
+        question = questions[current_index]
+
+        if score > question.max_points:
+            await message.answer(f"❌ Балл не может быть больше {question.max_points:.1f}")
+            return
+
+        if score < 0:
+            await message.answer("❌ Балл не может быть отрицательным")
+            return
+
+        # Сохраняем ответ
+        answers.append({"question_id": question.id, "score": score, "max_score": question.max_points})
+
+        next_index = current_index + 1
+        await state.update_data(exam_current_question=next_index, exam_answers=answers)
+
+        await message.answer(f"✅ Балл {score:.1f} принят за вопрос {current_index + 1}")
+
+        log_user_action(message.from_user.id, "exam_score_entered", f"Балл {score} за вопрос {current_index + 1}")
+
+        if next_index < len(questions):
+            question = questions[next_index]
+            text = (
+                f"<b>Вопрос {next_index + 1}:</b>\n\n"
+                f"{question.question_text}\n\n"
+                f"🎯 <b>Максимальный балл:</b> {question.max_points:.1f}\n\n"
+                "💡 Введи балл:"
+            )
+            await message.answer(text, parse_mode="HTML")
+        else:
+            await _show_exam_results(message, state, session)
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при обработке балла")
+        log_user_error(message.from_user.id, "process_exam_score_error", str(e))
+
+
+async def _show_exam_results(message, state: FSMContext, session: AsyncSession):
+    """Показ результатов экзамена"""
+    try:
+        data = await state.get_data()
+        assignment_id = data.get("exam_assignment_id")
+        answers = data.get("exam_answers", [])
+        company_id = data.get("company_id")
+
+        assignment = await AssessmentAssignmentRepository(session).get_by_id(assignment_id, company_id=company_id)
+        examinee = assignment.trainee
+        exam = assignment.attestation
+
+        total_score = sum(a["score"] for a in answers)
+        max_score = sum(a["max_score"] for a in answers)
+        is_passed = total_score >= exam.passing_score
+
+        # Создаем результат
+        result = await AssessmentResultRepository(session).create(
+            examinee.id,
+            exam.id,
+            assignment.manager_id,
+            total_score,
+            max_score,
+            is_passed,
+            company_id=company_id,
+        )
+
+        if result:
+            for answer in answers:
+                await AssessmentResultRepository(session).save_question_result(
+                    result.id, answer["question_id"], answer["score"], answer["max_score"]
+                )
+
+        # Завершаем сессию
+        await AssessmentAssignmentRepository(session).complete_session(
+            assignment_id,
+            total_score,
+            max_score,
+            is_passed,
+            company_id=company_id,
+        )
+
+        await session.commit()
+
+        status_emoji = "🟢" if is_passed else "🔴"
+        passed_text = "пройден" if is_passed else "не пройден"
+
+        text = (
+            f"{status_emoji} <b>Экзамен {passed_text}</b>\n\n"
+            f"{status_emoji} <b>Экзамен:</b> {exam.name}\n"
+            f"{status_emoji} <b>Экзаменуемый:</b> {examinee.full_name}\n"
+            f"{status_emoji} <b>Набрано баллов:</b> {total_score:.1f}\n"
+            f"{status_emoji} <b>Проходной балл:</b> {exam.passing_score:.1f}\n"
+            f"📍 <b>Объект стажировки:</b> {examinee.internship_object.name if examinee.internship_object else 'Не указан'}\n"
+            f"📍 <b>Объект работы:</b> {examinee.work_object.name if examinee.work_object else 'Не указан'}"
+        )
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")]]
+        )
+
+        await message.answer(text, parse_mode="HTML", reply_markup=keyboard)
+
+        # Уведомление сдающему о результате
+        await _send_exam_result_notification(session, message.bot, examinee, exam, total_score, is_passed, assignment)
+
+        await state.clear()
+        await state.update_data(company_id=company_id)
+
+        log_user_action(
+            message.from_user.id,
+            "exam_completed",
+            f"Экзамен {exam.name} для {examinee.full_name}: {total_score}/{max_score}, пройден: {is_passed}",
+        )
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при показе результатов")
+        log_user_error(message.from_user.id, "show_exam_results_error", str(e))
+
+
+async def _send_exam_result_notification(
+    session: AsyncSession,
+    bot,
+    examinee,
+    exam,
+    total_score: float,
+    is_passed: bool,
+    assignment,
+):
+    """Уведомление сдающему о результате экзамена"""
+    try:
+        if is_passed:
+            text = (
+                f"✅ <b>Экзамен «{exam.name}» пройден!</b>\n\n"
+                f"🎯 <b>Набрано баллов:</b> {total_score:.1f}\n"
+                f"🏁 <b>Проходной балл:</b> {exam.passing_score:.1f}\n"
+                f"👨‍⚖️ <b>Экзаменатор:</b> {assignment.manager.full_name}"
+            )
+        else:
+            text = (
+                f"❌ <b>Экзамен «{exam.name}» не пройден</b>\n\n"
+                f"🎯 <b>Набрано баллов:</b> {total_score:.1f}\n"
+                f"🏁 <b>Проходной балл:</b> {exam.passing_score:.1f}\n"
+                f"👨‍⚖️ <b>Экзаменатор:</b> {assignment.manager.full_name}\n\n"
+                "Свяжись с руководителем для пересдачи"
+            )
+
+        await bot.send_message(chat_id=examinee.tg_id, text=text, parse_mode="HTML")
+
+    except Exception as e:
+        log_user_error(0, "exam_result_notification_error", str(e))
+
+
+# ================== Flow H: Сдать экзамен (read-only для сдающего) ==================
+
+
+@router.callback_query(F.data == "exam_take", ExamStates.main_menu)
+async def callback_exam_take(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Список назначенных экзаменов для сдающего (read-only)"""
+    try:
+        await callback.answer()
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+        if not user:
+            await callback.message.edit_text("Ты не зарегистрирован в системе.")
+            return
+
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        assignments = await AssessmentAssignmentRepository(session).get_for_examinee(user.id, company_id=company_id)
+
+        if not assignments:
+            await callback.message.edit_text(
+                "📝 <b>Мои экзамены</b>\n\nУ тебя пока нет назначенных экзаменов.",
+                parse_mode="HTML",
+                reply_markup=InlineKeyboardMarkup(
+                    inline_keyboard=[[InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_menu")]]
+                ),
+            )
+            return
+
+        text = "📝 <b>Мои экзамены</b>\n\nНазначенные экзамены:\n\n"
+
+        for assignment in assignments:
+            exam = assignment.attestation
+            examiner = assignment.manager
+
+            status_map = {
+                "assigned": "🟡 Назначен",
+                "in_progress": "🔄 В процессе",
+                "completed": "✅ Пройден",
+                "failed": "❌ Не пройден",
+            }
+            status = status_map.get(assignment.status, "❓")
+
+            text += (
+                f"📋 <b>Экзамен:</b> {exam.name}\n"
+                f"👨‍⚖️ <b>Экзаменатор:</b> {examiner.full_name if examiner else '?'}\n"
+                f"📊 <b>Статус:</b> {status}\n\n"
+            )
+
+        text += "Свяжитесь с руководителем, чтобы подтвердить все детали"
+
+        keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[[InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_menu")]]
+        )
+
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+        await state.set_state(ExamStates.viewing_my_exams)
+
+        log_user_action(user.tg_id, "exam_take_list", "Просмотр назначенных экзаменов")
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_take_error", str(e))

--- a/src/bot/handlers/exams/exam_menu.py
+++ b/src/bot/handlers/exams/exam_menu.py
@@ -1,0 +1,447 @@
+"""
+Обработчики для РЕДАКТОРА Экзаменов: меню, создание, карточка, удаление.
+"""
+
+from aiogram import F, Router
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bot.database.db import get_user_by_tg_id
+from bot.keyboards.keyboards import (
+    get_exam_card_keyboard,
+    get_exam_confirm_delete_keyboard,
+    get_exam_menu_keyboard,
+    get_exam_questions_keyboard,
+    is_main_menu_text,
+)
+from bot.repositories import AssessmentRepository
+from bot.states.states import ExamStates
+from bot.utils.auth.auth import check_auth
+from bot.utils.logger import log_user_action, log_user_error
+
+router = Router()
+
+
+def _user_has_role(user, role_name: str) -> bool:
+    """Проверяет наличие роли у пользователя"""
+    return any(r.name == role_name for r in user.roles)
+
+
+async def _get_user_exam_roles(user) -> dict:
+    """Определяет ролевые флаги пользователя для экзаменов"""
+    is_recruiter = _user_has_role(user, "Рекрутер")
+    is_mentor = _user_has_role(user, "Наставник")
+    is_manager = _user_has_role(user, "Руководитель")
+    is_employee = _user_has_role(user, "Сотрудник")
+    # Экзаменатор: руководитель, сотрудник или рекрутер
+    is_examiner = is_manager or is_employee or is_recruiter
+    return {
+        "is_recruiter": is_recruiter,
+        "is_mentor": is_mentor,
+        "is_examiner": is_examiner,
+    }
+
+
+async def show_exam_menu(message_or_callback, state: FSMContext, session: AsyncSession, user=None):
+    """Показ главного меню экзаменов"""
+    try:
+        if user is None:
+            tg_id = (
+                message_or_callback.from_user.id
+                if hasattr(message_or_callback, "from_user")
+                else message_or_callback.message.from_user.id
+            )
+            user = await get_user_by_tg_id(session, tg_id)
+
+        if not user:
+            return
+
+        roles = await _get_user_exam_roles(user)
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        exams = await AssessmentRepository(session).get_all(company_id, assessment_type="exam")
+
+        text = "🔖<b>РЕДАКТОР Экзаменов</b>\nВыбери нужное действие"
+
+        keyboard = get_exam_menu_keyboard(exams, **roles)
+
+        if isinstance(message_or_callback, CallbackQuery):
+            await message_or_callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+        else:
+            await message_or_callback.answer(text, parse_mode="HTML", reply_markup=keyboard)
+
+        await state.set_state(ExamStates.main_menu)
+
+    except Exception as e:
+        log_user_error(0, "show_exam_menu_error", str(e))
+
+
+# ================== Flow B: Вход в меню экзаменов ==================
+
+
+@router.message(F.text == "Экзамены 📝")
+async def cmd_exams(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработчик reply-кнопки «Экзамены 📝»"""
+    try:
+        is_auth = await check_auth(message, state, session)
+        if not is_auth:
+            return
+
+        user = await get_user_by_tg_id(session, message.from_user.id)
+        if not user:
+            await message.answer("Ты не зарегистрирован в системе.")
+            return
+
+        # Стажёрам экзамены недоступны
+        if _user_has_role(user, "Стажер") or _user_has_role(user, "Стажёр"):
+            await message.answer("❌ Экзамены не доступны для стажёров.")
+            return
+
+        await show_exam_menu(message, state, session, user)
+        log_user_action(user.tg_id, "exam_menu_opened", "Открыто меню экзаменов")
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при открытии экзаменов")
+        log_user_error(message.from_user.id, "cmd_exams_error", str(e))
+
+
+@router.callback_query(F.data == "exam_menu")
+async def callback_exam_menu(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Обработчик inline-кнопки «Экзамены» (для наставника)"""
+    try:
+        await callback.answer()
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+        if not user:
+            await callback.message.edit_text("Ты не зарегистрирован в системе.")
+            return
+
+        await show_exam_menu(callback, state, session, user)
+        log_user_action(user.tg_id, "exam_menu_opened", "Открыто меню экзаменов (inline)")
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка при открытии экзаменов")
+        log_user_error(callback.from_user.id, "callback_exam_menu_error", str(e))
+
+
+@router.callback_query(F.data == "exam_back_to_menu")
+async def callback_exam_back_to_menu(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Возврат в меню экзаменов"""
+    try:
+        await callback.answer()
+        await show_exam_menu(callback, state, session)
+    except Exception as e:
+        log_user_error(callback.from_user.id, "exam_back_to_menu_error", str(e))
+
+
+# ================== Flow C: Создание экзамена ==================
+
+
+@router.callback_query(F.data == "exam_create", ExamStates.main_menu)
+async def callback_exam_create(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Начало создания экзамена"""
+    try:
+        await callback.answer()
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+        if not user or not _user_has_role(user, "Рекрутер"):
+            await callback.message.edit_text("❌ Только рекрутер может создавать экзамены.")
+            return
+
+        text = "🔖<b>РЕДАКТОР Экзаменов</b> / Создание экзамена\n🟡<b>Название:</b> отправь название"
+
+        await callback.message.edit_text(text, parse_mode="HTML")
+        await state.set_state(ExamStates.waiting_for_exam_name)
+
+        log_user_action(callback.from_user.id, "exam_create_started", "Начато создание экзамена")
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_create_error", str(e))
+
+
+@router.message(ExamStates.waiting_for_exam_name)
+async def process_exam_name(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработка названия экзамена"""
+    try:
+        name = message.text.strip()
+
+        if is_main_menu_text(name):
+            return
+
+        if len(name) < 2 or len(name) > 200:
+            await message.answer("❌ Название должно быть от 2 до 200 символов. Попробуй еще раз:")
+            return
+
+        await state.update_data(exam_name=name, exam_questions=[])
+
+        text = (
+            "🔖<b>РЕДАКТОР Экзаменов</b> / Создание экзамена\n"
+            f"🟢<b>Название:</b> {name}\n"
+            "🟡<b>Вопрос 1:</b> введи текст вопроса и описание возможных критериев ответа цифрой\n\n"
+            "💡 <b>Введи ВЕСЬ БЛОК</b> (вопрос + правильный ответ + критерии оценки)"
+        )
+
+        await message.answer(text, parse_mode="HTML")
+        await state.set_state(ExamStates.waiting_for_exam_question)
+
+        log_user_action(message.from_user.id, "exam_name_set", f"Название экзамена: {name}")
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при обработке названия")
+        log_user_error(message.from_user.id, "process_exam_name_error", str(e))
+
+
+@router.message(ExamStates.waiting_for_exam_question)
+async def process_exam_question(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработка вопросов экзамена"""
+    try:
+        question_text = message.text.strip()
+
+        if is_main_menu_text(question_text):
+            return
+
+        data = await state.get_data()
+        questions = data.get("exam_questions") or []
+        exam_name = data.get("exam_name", "")
+
+        question_number = len(questions) + 1
+        questions.append(
+            {
+                "number": question_number,
+                "text": question_text,
+                "max_points": 10,
+            }
+        )
+
+        await state.update_data(exam_questions=questions)
+
+        # Показываем прогресс
+        questions_text = ""
+        recent = questions[-3:] if len(questions) > 3 else questions
+
+        for q in recent:
+            questions_text += f"✅ <b>Вопрос {q['number']}:</b>\n{q['text']}\n\n"
+
+        if len(questions) > 3:
+            questions_text = f"📝 <i>Добавлено вопросов: {len(questions) - 3} + последние 3:</i>\n\n" + questions_text
+
+        text = (
+            "🔖<b>РЕДАКТОР Экзаменов</b> / Создание экзамена\n"
+            f"🟢<b>Название:</b> {exam_name}\n"
+            f"📊 <b>Всего вопросов:</b> {question_number}\n\n"
+            f"{questions_text}"
+            f"🟡<b>Вопрос {question_number + 1}:</b> введи текст вопроса\n\n"
+            "Для продолжения отправь текст вопроса или сохрани текущие вопросы"
+        )
+
+        await message.answer(text, reply_markup=get_exam_questions_keyboard(), parse_mode="HTML")
+
+        log_user_action(message.from_user.id, "exam_question_added", f"Вопрос {question_number}")
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при обработке вопроса")
+        log_user_error(message.from_user.id, "process_exam_question_error", str(e))
+
+
+@router.callback_query(F.data == "exam_save_questions", ExamStates.waiting_for_exam_question)
+async def callback_exam_save_questions(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Сохранение вопросов экзамена → запрос проходного балла"""
+    try:
+        await callback.answer()
+
+        data = await state.get_data()
+        exam_name = data.get("exam_name", "")
+        questions = data.get("exam_questions") or []
+
+        if not questions:
+            await callback.answer("Нет вопросов для сохранения", show_alert=True)
+            return
+
+        text = (
+            "🔖<b>РЕДАКТОР Экзаменов</b> / Создание экзамена\n"
+            f"🟢<b>Название:</b> {exam_name}\n\n"
+            "✅ Добавление вопросов завершено.\n"
+            "Теперь введи проходной балл для экзамена"
+        )
+
+        await callback.message.edit_text(text, parse_mode="HTML")
+        await state.set_state(ExamStates.waiting_for_exam_passing_score)
+
+    except Exception as e:
+        await callback.answer("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_save_questions_error", str(e))
+
+
+@router.message(ExamStates.waiting_for_exam_passing_score)
+async def process_exam_passing_score(message: Message, state: FSMContext, session: AsyncSession):
+    """Обработка проходного балла и создание экзамена в БД"""
+    try:
+        if is_main_menu_text(message.text.strip()):
+            return
+
+        try:
+            passing_score = float(message.text.strip())
+            if passing_score <= 0:
+                await message.answer("❌ Проходной балл должен быть положительным числом")
+                return
+        except ValueError:
+            await message.answer("❌ Введи корректное число (например: 30)")
+            return
+
+        data = await state.get_data()
+        exam_name = data.get("exam_name")
+        questions = data.get("exam_questions") or []
+        company_id = data.get("company_id")
+
+        user = await get_user_by_tg_id(session, message.from_user.id)
+
+        # Создаём экзамен в БД
+        repo = AssessmentRepository(session)
+        exam = await repo.create(
+            name=exam_name,
+            passing_score=passing_score,
+            creator_id=user.id,
+            company_id=company_id,
+            assessment_type="exam",
+        )
+
+        if exam:
+            for q in questions:
+                await repo.add_question(
+                    attestation_id=exam.id,
+                    question_text=q["text"],
+                    max_points=q["max_points"],
+                    question_number=q["number"],
+                )
+
+        text = (
+            "🔖<b>РЕДАКТОР Экзаменов</b> / Создание экзамена\n"
+            f"🟢<b>Название:</b> {exam_name}\n\n"
+            f"✅ Экзамен «{exam_name}» успешно создан!\n"
+            f"📋 Вопросов добавлено: {len(questions)}\n"
+            f"💕 Проходной балл: {passing_score:.1f}\n\n"
+            "Теперь ты можешь передать данный экзамен нужному экзаменатору и экзаменуемому"
+        )
+
+        await message.answer(text, parse_mode="HTML")
+
+        # Показываем обновленное меню
+        await show_exam_menu(message, state, session, user)
+
+        log_user_action(message.from_user.id, "exam_created", f"Экзамен: {exam_name}")
+
+    except Exception as e:
+        await message.answer("Произошла ошибка при создании экзамена")
+        log_user_error(message.from_user.id, "process_exam_passing_score_error", str(e))
+
+
+# ================== Flow D: Карточка экзамена ==================
+
+
+@router.callback_query(F.data.startswith("exam_view:"), ExamStates.main_menu)
+async def callback_exam_view(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Просмотр карточки экзамена"""
+    try:
+        await callback.answer()
+
+        exam_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+        if not exam:
+            await callback.message.edit_text("Экзамен не найден")
+            return
+
+        user = await get_user_by_tg_id(session, callback.from_user.id)
+        roles = await _get_user_exam_roles(user)
+
+        # Формируем текст карточки
+        questions_text = ""
+        for q in exam.questions:
+            questions_text += (
+                f"  ✅ <b>Вопрос {q.question_number}:</b>\n     {q.question_text}\n     Ставь {q.max_points:.0f}\n\n"
+            )
+
+        text = (
+            f"🔖<b>РЕДАКТОР Экзаменов</b>\n"
+            f"📋 <b>Экзамен:</b> {exam.name}\n"
+            f"📋 <b>Всего вопросов:</b> {len(exam.questions)}\n\n"
+            f"{questions_text}"
+            f"💕 <b>Проходной балл:</b> {exam.passing_score:.1f}\n"
+            f"🎯 <b>Максимальный балл:</b> {exam.max_score:.1f}"
+        )
+
+        keyboard = get_exam_card_keyboard(
+            exam_id,
+            is_recruiter=roles["is_recruiter"],
+            can_assign=roles["is_recruiter"] or roles["is_mentor"],
+        )
+
+        await callback.message.edit_text(text, parse_mode="HTML", reply_markup=keyboard)
+
+        await state.update_data(current_exam_id=exam_id)
+        await state.set_state(ExamStates.viewing_exam)
+
+        log_user_action(callback.from_user.id, "exam_view", f"Просмотр экзамена: {exam.name}")
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка при просмотре экзамена")
+        log_user_error(callback.from_user.id, "exam_view_error", str(e))
+
+
+# ================== Удаление экзамена ==================
+
+
+@router.callback_query(F.data.startswith("exam_delete:"), ExamStates.viewing_exam)
+async def callback_exam_delete(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Подтверждение удаления экзамена"""
+    try:
+        await callback.answer()
+
+        exam_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        exam = await AssessmentRepository(session).get_by_id(exam_id, company_id=company_id)
+        if not exam:
+            await callback.message.edit_text("Экзамен не найден")
+            return
+
+        text = f"🗑 <b>Удалить экзамен «{exam.name}»?</b>\n\nЭто действие нельзя будет отменить."
+
+        await callback.message.edit_text(
+            text, parse_mode="HTML", reply_markup=get_exam_confirm_delete_keyboard(exam_id)
+        )
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка")
+        log_user_error(callback.from_user.id, "exam_delete_error", str(e))
+
+
+@router.callback_query(F.data.startswith("exam_confirm_delete:"), ExamStates.viewing_exam)
+async def callback_exam_confirm_delete(callback: CallbackQuery, state: FSMContext, session: AsyncSession):
+    """Фактическое удаление экзамена"""
+    try:
+        await callback.answer()
+
+        exam_id = int(callback.data.split(":")[1])
+        data = await state.get_data()
+        company_id = data.get("company_id")
+
+        success = await AssessmentRepository(session).delete(exam_id, company_id=company_id)
+
+        if success:
+            await callback.message.edit_text("✅ Экзамен успешно удалён")
+            log_user_action(callback.from_user.id, "exam_deleted", f"Удалён экзамен ID: {exam_id}")
+        else:
+            await callback.message.edit_text("❌ Не удалось удалить экзамен. Возможно, он используется в траекториях.")
+
+        await show_exam_menu(callback, state, session)
+
+    except Exception as e:
+        await callback.message.edit_text("Произошла ошибка при удалении")
+        log_user_error(callback.from_user.id, "exam_confirm_delete_error", str(e))

--- a/src/bot/keyboards/keyboards.py
+++ b/src/bot/keyboards/keyboards.py
@@ -39,6 +39,8 @@ MAIN_MENU_TEXTS = {
     "☰ Главное меню",
     # Руководитель
     "Аттестация ✔️",
+    # Экзамены
+    "Экзамены 📝",
     # Главное меню (текст)
     "≡ Главное меню",
 }
@@ -109,6 +111,7 @@ def get_recruiter_keyboard() -> ReplyKeyboardMarkup:
             [KeyboardButton(text="Рассылка ✈️")],
             [KeyboardButton(text="Тесты 📄")],
             [KeyboardButton(text="Мои тесты 📋")],
+            [KeyboardButton(text="Экзамены 📝")],
             [KeyboardButton(text="Наставники 🦉")],
             [KeyboardButton(text="Стажеры 🐣")],
             [KeyboardButton(text="Группы 🗂️")],
@@ -142,6 +145,7 @@ def get_mentor_inline_menu() -> InlineKeyboardMarkup:
         [InlineKeyboardButton(text="Мой профиль 🦸🏻‍♂️", callback_data="mentor_profile")],
         [InlineKeyboardButton(text="База знаний 📒", callback_data="mentor_knowledge_base")],
         [InlineKeyboardButton(text="Мои тесты 🗒", callback_data="mentor_my_tests")],
+        [InlineKeyboardButton(text="Экзамены 📝", callback_data="exam_menu")],
         [InlineKeyboardButton(text="Панель наставника 🎓", callback_data="mentor_panel")],
         [InlineKeyboardButton(text="Помощь ❓", callback_data="mentor_help")],
     ])
@@ -153,6 +157,7 @@ def get_employee_keyboard() -> ReplyKeyboardMarkup:
         keyboard=[
             [KeyboardButton(text="Мой профиль 🦸🏻‍♂️")],
             [KeyboardButton(text="Мои тесты 📋")],
+            [KeyboardButton(text="Экзамены 📝")],
             [KeyboardButton(text="База знаний 📁️")],
             [KeyboardButton(text="Помощь ❓")]
         ],
@@ -167,6 +172,7 @@ def get_manager_keyboard() -> ReplyKeyboardMarkup:
         keyboard=[
             [KeyboardButton(text="Мой профиль 🦸🏻‍♂️")],
             [KeyboardButton(text="Аттестация ✔️")],
+            [KeyboardButton(text="Экзамены 📝")],
             [KeyboardButton(text="Мои тесты 📋")],
             [KeyboardButton(text="База знаний 📁️")],
             [KeyboardButton(text="Помощь ❓")]
@@ -1490,6 +1496,78 @@ def get_attestation_questions_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
+# ================== ЭКЗАМЕНЫ ==================
+
+
+def get_exam_menu_keyboard(
+    exams: list, is_recruiter: bool = False, is_examiner: bool = False, is_mentor: bool = False,
+) -> InlineKeyboardMarkup:
+    """Главное меню РЕДАКТОРА Экзаменов (ролезависимое)"""
+    keyboard = []
+
+    # Кнопка «Провести экзамен» — для экзаменаторов (руководитель, сотрудник, рекрутер)
+    if is_examiner:
+        keyboard.append([InlineKeyboardButton(text="Провести экзамен", callback_data="exam_conduct")])
+
+    # Кнопка «Сдать экзамен» — для всех
+    keyboard.append([InlineKeyboardButton(text="Сдать экзамен", callback_data="exam_take")])
+
+    # Кнопка «Создать экзамен» — только рекрутер
+    if is_recruiter:
+        keyboard.append([InlineKeyboardButton(text="➕ Создать экзамен", callback_data="exam_create")])
+
+    # Список существующих экзаменов — только рекрутер и наставник
+    if is_recruiter or is_mentor:
+        for exam in exams:
+            keyboard.append([InlineKeyboardButton(
+                text=f"── {exam.name}",
+                callback_data=f"exam_view:{exam.id}",
+            )])
+
+    keyboard.append([InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")])
+
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_exam_card_keyboard(
+    exam_id: int, is_recruiter: bool = False, can_assign: bool = False,
+) -> InlineKeyboardMarkup:
+    """Клавиатура карточки экзамена"""
+    keyboard = []
+
+    if is_recruiter:
+        keyboard.append([InlineKeyboardButton(text="🗑 Удалить", callback_data=f"exam_delete:{exam_id}")])
+
+    if can_assign:
+        keyboard.append([InlineKeyboardButton(text="📌 Назначить", callback_data=f"exam_assign:{exam_id}")])
+
+    keyboard.append([InlineKeyboardButton(text="🔙 Назад к экзаменам", callback_data="exam_back_to_menu")])
+    keyboard.append([InlineKeyboardButton(text="≡ Главное меню", callback_data="main_menu")])
+
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_exam_questions_keyboard() -> InlineKeyboardMarkup:
+    """Клавиатура для управления вопросами экзамена при создании"""
+    keyboard = [
+        [InlineKeyboardButton(text="Сохранить вопросы", callback_data="exam_save_questions")]
+    ]
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
+def get_exam_examiner_list_keyboard(examiners: list) -> InlineKeyboardMarkup:
+    """Клавиатура выбора экзаменатора"""
+    keyboard = []
+    for user in examiners:
+        role_name = user.roles[0].name if user.roles else ""
+        keyboard.append([InlineKeyboardButton(
+            text=f"{user.full_name} ({role_name})",
+            callback_data=f"exam_examiner:{user.id}",
+        )])
+    keyboard.append([InlineKeyboardButton(text="🔙 Назад", callback_data="exam_back_to_card")])
+    return InlineKeyboardMarkup(inline_keyboard=keyboard)
+
+
 class UserFilterKeyboards:
     """Генератор клавиатур фильтрации пользователей.
 
@@ -1641,6 +1719,14 @@ class UserFilterKeyboards:
         return InlineKeyboardMarkup(inline_keyboard=keyboard)
 
 
+exam_filters = UserFilterKeyboards(
+    prefix="ef",
+    emojis={"all": "👥", "groups": "🟢", "objects": "🔴", "search": "🟣"},
+    per_page=8,
+    show_role=False,
+    back_text="🔙 Назад",
+)
+
 user_edit_filters = UserFilterKeyboards(
     prefix="uf",
     emojis={"all": "👥", "groups": "🗂️", "objects": "📍", "search": "🔍"},
@@ -1648,6 +1734,16 @@ user_edit_filters = UserFilterKeyboards(
     show_role=True,
     back_text="↩️ Назад к фильтрам",
 )
+
+
+def get_exam_confirm_delete_keyboard(exam_id: int) -> InlineKeyboardMarkup:
+    """Клавиатура подтверждения удаления экзамена"""
+    return InlineKeyboardMarkup(inline_keyboard=[
+        [
+            InlineKeyboardButton(text="✅ Да, удалить", callback_data=f"exam_confirm_delete:{exam_id}"),
+            InlineKeyboardButton(text="❌ Отмена", callback_data=f"exam_view:{exam_id}"),
+        ]
+    ])
 
 
 def get_new_users_list_keyboard(users: list, page: int = 0, per_page: int = 5) -> InlineKeyboardMarkup:

--- a/src/bot/repositories/assessment_assignment_repo.py
+++ b/src/bot/repositories/assessment_assignment_repo.py
@@ -130,6 +130,7 @@ class AssessmentAssignmentRepository(BaseRepository):
                 select(TraineeAttestation)
                 .options(
                     selectinload(TraineeAttestation.trainee).selectinload(User.work_object),
+                    selectinload(TraineeAttestation.trainee).selectinload(User.internship_object),
                     selectinload(TraineeAttestation.manager),
                     selectinload(TraineeAttestation.attestation).selectinload(Attestation.questions),
                     selectinload(TraineeAttestation.assigned_by),
@@ -437,6 +438,13 @@ class AssessmentAssignmentRepository(BaseRepository):
     ) -> List[User]:
         """Получение пользователей для назначения экзамена с фильтрацией"""
         try:
+            # Исключаем стажёров — по ТЗ им нельзя назначить экзамен
+            trainee_role_subquery = (
+                select(user_roles.c.user_id)
+                .join(Role, user_roles.c.role_id == Role.id)
+                .where(Role.name.in_(["Стажер", "Стажёр"]))
+            )
+
             query = (
                 select(User)
                 .options(
@@ -449,6 +457,7 @@ class AssessmentAssignmentRepository(BaseRepository):
                     User.is_active == True,
                     User.is_activated == True,
                     User.company_id == company_id,
+                    User.id.not_in(trainee_role_subquery),
                 )
             )
 

--- a/src/bot/repositories/assessment_assignment_repo.py
+++ b/src/bot/repositories/assessment_assignment_repo.py
@@ -338,6 +338,137 @@ class AssessmentAssignmentRepository(BaseRepository):
             logger.error(f"Ошибка проверки завершения этапов для стажера {trainee_id}: {e}")
             return False
 
+    async def get_examiners(self, company_id: int = None) -> List[User]:
+        """Получение списка экзаменаторов (руководители + сотрудники + рекрутеры)"""
+        try:
+            query = (
+                select(User)
+                .options(selectinload(User.roles))
+                .join(user_roles, User.id == user_roles.c.user_id)
+                .join(Role, user_roles.c.role_id == Role.id)
+                .where(
+                    Role.name.in_(["Руководитель", "Сотрудник", "Рекрутер"]),
+                    User.is_active == True,
+                    User.is_activated == True,
+                )
+            )
+
+            if company_id is not None:
+                query = query.where(User.company_id == company_id)
+
+            result = await self.session.execute(query)
+            return list(result.scalars().unique().all())
+
+        except Exception as e:
+            logger.error(f"Ошибка получения экзаменаторов: {e}")
+            return []
+
+    async def get_for_examinee(self, examinee_id: int, company_id: int = None) -> List[TraineeAttestation]:
+        """Получение назначенных экзаменов для сдающего"""
+        try:
+            query = (
+                select(TraineeAttestation)
+                .options(
+                    selectinload(TraineeAttestation.manager),
+                    selectinload(TraineeAttestation.attestation),
+                    selectinload(TraineeAttestation.assigned_by),
+                )
+                .join(Attestation, TraineeAttestation.attestation_id == Attestation.id)
+                .where(
+                    TraineeAttestation.trainee_id == examinee_id,
+                    TraineeAttestation.is_active == True,
+                    Attestation.assessment_type == "exam",
+                )
+            )
+
+            if company_id is not None:
+                query = query.join(User, TraineeAttestation.trainee_id == User.id).where(User.company_id == company_id)
+
+            query = query.order_by(TraineeAttestation.assigned_date.desc())
+
+            result = await self.session.execute(query)
+            return list(result.scalars().all())
+
+        except Exception as e:
+            logger.error(f"Ошибка получения экзаменов для сдающего {examinee_id}: {e}")
+            return []
+
+    async def get_exam_assignments_for_examiner(
+        self, examiner_id: int, company_id: int = None
+    ) -> List[TraineeAttestation]:
+        """Получение назначенных экзаменов для экзаменатора (аналог get_for_manager, но для экзаменов)"""
+        try:
+            query = (
+                select(TraineeAttestation)
+                .options(
+                    selectinload(TraineeAttestation.trainee).selectinload(User.work_object),
+                    selectinload(TraineeAttestation.trainee).selectinload(User.internship_object),
+                    selectinload(TraineeAttestation.attestation),
+                    selectinload(TraineeAttestation.assigned_by),
+                )
+                .join(Attestation, TraineeAttestation.attestation_id == Attestation.id)
+                .join(User, TraineeAttestation.trainee_id == User.id)
+                .where(
+                    TraineeAttestation.manager_id == examiner_id,
+                    TraineeAttestation.is_active == True,
+                    Attestation.assessment_type == "exam",
+                    TraineeAttestation.status.in_(["assigned", "in_progress"]),
+                )
+            )
+
+            if company_id is not None:
+                query = query.where(User.company_id == company_id)
+
+            query = query.order_by(TraineeAttestation.assigned_date.desc())
+
+            result = await self.session.execute(query)
+            return list(result.scalars().all())
+
+        except Exception as e:
+            logger.error(f"Ошибка получения экзаменов для экзаменатора {examiner_id}: {e}")
+            return []
+
+    async def get_users_for_exam_assignment(
+        self,
+        company_id: int,
+        filter_type: str = "all",
+        filter_id: int = None,
+        search_query: str = None,
+    ) -> List[User]:
+        """Получение пользователей для назначения экзамена с фильтрацией"""
+        try:
+            query = (
+                select(User)
+                .options(
+                    selectinload(User.roles),
+                    selectinload(User.groups),
+                    selectinload(User.work_object),
+                    selectinload(User.internship_object),
+                )
+                .where(
+                    User.is_active == True,
+                    User.is_activated == True,
+                    User.company_id == company_id,
+                )
+            )
+
+            if filter_type == "group" and filter_id is not None:
+                query = query.join(user_groups, User.id == user_groups.c.user_id).where(
+                    user_groups.c.group_id == filter_id
+                )
+            elif filter_type == "object" and filter_id is not None:
+                query = query.where(or_(User.work_object_id == filter_id, User.internship_object_id == filter_id))
+            elif filter_type == "search" and search_query:
+                query = query.where(User.full_name.ilike(f"%{search_query}%"))
+
+            query = query.order_by(User.full_name)
+            result = await self.session.execute(query)
+            return list(result.scalars().unique().all())
+
+        except Exception as e:
+            logger.error(f"Ошибка получения пользователей для экзамена: {e}")
+            return []
+
     async def cleanup_duplicates(self, user_id: int) -> int:
         """Очистка дублирующих аттестаций для пользователя"""
         try:

--- a/src/bot/repositories/assessment_repo.py
+++ b/src/bot/repositories/assessment_repo.py
@@ -23,8 +23,9 @@ class AssessmentRepository(BaseRepository):
         passing_score: float,
         creator_id: int,
         company_id: int = None,
+        assessment_type: str = "attestation",
     ) -> Optional[Attestation]:
-        """Создание новой аттестации (с привязкой к компании)"""
+        """Создание новой аттестации/экзамена (с привязкой к компании)"""
         try:
             attestation = Attestation(
                 name=name,
@@ -32,6 +33,7 @@ class AssessmentRepository(BaseRepository):
                 max_score=0,  # Будет обновлено при добавлении вопросов
                 created_by_id=creator_id,
                 company_id=company_id,
+                assessment_type=assessment_type,
             )
 
             self.session.add(attestation)
@@ -77,8 +79,8 @@ class AssessmentRepository(BaseRepository):
             await self.session.rollback()
             return None
 
-    async def get_all(self, company_id: int = None) -> List[Attestation]:
-        """Получение всех аттестаций (с фильтрацией по компании)
+    async def get_all(self, company_id: int = None, assessment_type: str = "attestation") -> List[Attestation]:
+        """Получение всех аттестаций/экзаменов (с фильтрацией по компании и типу)
 
         КРИТИЧЕСКИ ВАЖНО: Если company_id = None, возвращается пустой список (deny-by-default)
         для предотвращения утечки данных между компаниями.
@@ -98,6 +100,7 @@ class AssessmentRepository(BaseRepository):
                     .where(
                         Attestation.is_active == True,
                         Attestation.company_id == company_id,
+                        Attestation.assessment_type == assessment_type,
                     )
                     .order_by(Attestation.created_date.desc())
                 )

--- a/src/bot/states/states.py
+++ b/src/bot/states/states.py
@@ -390,6 +390,36 @@ class CompanyJoinStates(StatesGroup):
     waiting_for_role_selection = State()
 
 
+class ExamStates(StatesGroup):
+    """Состояния для работы с экзаменами"""
+
+    # Меню экзаменов
+    main_menu = State()
+
+    # Создание экзамена (рекрутер)
+    waiting_for_exam_name = State()
+    waiting_for_exam_question = State()
+    waiting_for_exam_passing_score = State()
+
+    # Карточка экзамена
+    viewing_exam = State()
+
+    # Назначение экзамена
+    selecting_examiner = State()  # Выбор экзаменатора
+    selecting_examinee_filter = State()  # Выбор способа поиска сдающего
+    searching_examinee_by_name = State()  # Поиск по ФИО
+    selecting_examinee = State()  # Выбор сдающего из списка
+    viewing_examinee_card = State()  # Карточка сдающего перед назначением
+
+    # Проведение экзамена (экзаменатор)
+    selecting_examinee_for_exam = State()  # Выбор сдающего из списка назначенных
+    viewing_exam_details = State()  # Детали перед началом
+    waiting_for_exam_score = State()  # Ввод балла за вопрос
+
+    # Сдать экзамен (сдающий — read-only)
+    viewing_my_exams = State()
+
+
 class CompanyManagementStates(StatesGroup):
     """Состояния для управления компанией (для рекрутеров)"""
 

--- a/src/tests/e2e/test_exam_flows.py
+++ b/src/tests/e2e/test_exam_flows.py
@@ -223,7 +223,61 @@ class TestTraineeExamBlocked:
 
 
 # =========================================================================
-# Класс 7: Рекрутер назначает экзамен
+# Класс 7: Стажёр не попадает в список сдающих при назначении экзамена
+# =========================================================================
+
+
+class TestTraineeExcludedFromExamAssignment:
+    """По ТЗ стажёр не может быть назначен сдающим экзамена."""
+
+    async def test_step1_trainee_not_in_examinee_list(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер открывает список сдающих — стажёр отсутствует."""
+        await wait_between_actions()
+
+        # Открываем меню экзаменов
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+
+        # Находим экзамен и открываем карточку
+        exam_btn = recruiter.find_button_data(resp, text_contains="E2E Экзамен Кофе", data_prefix="exam_view:")
+        assert exam_btn, f"Exam not found. Buttons: {recruiter.get_button_texts(resp)}"
+        resp = await recruiter.click_and_wait(resp, data=exam_btn, wait_pattern="E2E Экзамен Кофе")
+
+        # Нажимаем «Назначить»
+        assign_btn = recruiter.find_button_data(resp, data_prefix="exam_assign:")
+        assert assign_btn, f"Assign button not found. Buttons: {recruiter.get_button_texts(resp)}"
+        resp = await recruiter.click_and_wait(resp, data=assign_btn, wait_pattern="Экзаменатор|экзаменатор")
+
+        # Выбираем экзаменатора (руководителя)
+        examiner_btn = recruiter.find_button_data(resp, text_contains="Руководителев", data_prefix="exam_examiner:")
+        assert examiner_btn, f"Examiner not found. Buttons: {recruiter.get_button_texts(resp)}"
+        resp = await recruiter.click_and_wait(resp, data=examiner_btn, wait_pattern="Сдающий|способ поиска")
+
+        # Нажимаем «Все пользователи»
+        all_btn = recruiter.find_button_data(resp, data_prefix="ef_all")
+        assert all_btn, f"'All users' button not found. Buttons: {recruiter.get_button_texts(resp)}"
+        resp = await recruiter.click_and_wait(resp, data=all_btn, wait_pattern="Найдено|Выбери")
+
+        # Получаем список имён
+        button_texts = recruiter.get_button_texts(resp)
+
+        # Стажёр (trainee1 = "Стажёров Первый") НЕ должен быть в списке сдающих
+        assert not any("Стажёров Первый" in b for b in button_texts), (
+            f"Trainee 'Стажёров Первый' should NOT be in examinee list. Buttons: {button_texts}"
+        )
+
+        # Сотрудник (trainee2 = "Стажёров Второй", перешёл в роль Сотрудник) ДОЛЖЕН быть
+        assert any("Стажёров Второй" in b for b in button_texts), (
+            f"Employee 'Стажёров Второй' should be in examinee list. Buttons: {button_texts}"
+        )
+
+        # Наставник тоже ДОЛЖЕН быть
+        assert any("Наставников" in b for b in button_texts), (
+            f"Mentor 'Наставников' should be in examinee list. Buttons: {button_texts}"
+        )
+
+
+# =========================================================================
+# Класс 8: Рекрутер назначает экзамен
 # =========================================================================
 
 

--- a/src/tests/e2e/test_exam_flows.py
+++ b/src/tests/e2e/test_exam_flows.py
@@ -1,0 +1,490 @@
+"""
+E2E Сценарий 9: Полные flow экзаменов по ролям.
+
+Покрывает:
+- Класс 1: Рекрутер создаёт экзамен (название, вопросы, проходной балл)
+- Класс 2: Меню рекрутера — полный набор кнопок + карточка с удалением/назначением
+- Класс 3: Меню наставника — список экзаменов, назначение, без создания/проведения
+- Класс 4: Меню руководителя — проведение/сдача, без создания/списка
+- Класс 5: Меню сотрудника — проведение/сдача, без создания/списка
+- Класс 6: Стажёр заблокирован
+- Класс 7: Рекрутер назначает экзамен (экзаменатор=руководитель, сдающий=наставник)
+- Класс 8: Руководитель проводит экзамен (вопросы, баллы, результат)
+- Класс 9: Наставник видит завершённый экзамен в «Сдать экзамен»
+
+Зависит от test_attestation_flows.py (order=8).
+"""
+
+import pytest
+
+from tests.e2e.helpers.bot_client import BotClient
+from tests.e2e.helpers.waiters import wait_between_actions
+
+pytestmark = [
+    pytest.mark.order(9),
+    pytest.mark.timeout(600),
+    pytest.mark.asyncio(loop_scope="session"),
+]
+
+
+# =========================================================================
+# Класс 1: Рекрутер создаёт экзамен
+# =========================================================================
+
+
+class TestExamCreation:
+    """Рекрутер создаёт экзамен: название → вопросы → проходной балл."""
+
+    async def test_step1_recruiter_opens_exam_menu(self, recruiter: BotClient):
+        """Рекрутер открывает меню экзаменов."""
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР Экзаменов|действие")
+        buttons = recruiter.get_button_texts(resp)
+        assert any("Создать экзамен" in b for b in buttons), f"No 'Создать' button. Buttons: {buttons}"
+        assert any("Провести экзамен" in b for b in buttons), f"No 'Провести' button. Buttons: {buttons}"
+        assert any("Сдать экзамен" in b for b in buttons), f"No 'Сдать' button. Buttons: {buttons}"
+
+    async def test_step2_recruiter_creates_exam(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер создаёт экзамен с 2 вопросами и проходным баллом 10."""
+        await wait_between_actions()
+
+        # Открываем меню и нажимаем «Создать»
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР Экзаменов")
+        resp = await recruiter.click_and_wait(resp, data=b"exam_create", wait_pattern="название|Название")
+
+        # Вводим название
+        resp = await recruiter.send_and_wait("E2E Экзамен Кофе", pattern="Вопрос 1")
+
+        # Вопрос 1
+        resp = await recruiter.send_and_wait(
+            "Правильно ли приготовлен эспрессо?",
+            pattern="Вопрос 2|Сохранить",
+        )
+
+        # Вопрос 2
+        resp = await recruiter.send_and_wait(
+            "Проверка темперовки",
+            pattern="Вопрос 3|сохрани",
+        )
+
+        # Сохраняем вопросы
+        resp = await recruiter.click_and_wait(
+            resp, data=b"exam_save_questions", wait_pattern="проходной балл|Проходной"
+        )
+
+        # Вводим проходной балл
+        resp = await recruiter.send_and_wait("10", pattern="успешно создан")
+
+        resp_text = resp.text or ""
+        assert "E2E Экзамен Кофе" in resp_text, f"Exam name not in response: {resp_text[:300]}"
+        shared_state["exam_name"] = "E2E Экзамен Кофе"
+
+    async def test_step3_exam_appears_in_list(self, recruiter: BotClient, shared_state: dict):
+        """Созданный экзамен появляется в списке меню рекрутера."""
+        await wait_between_actions()
+
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        exam_btn = recruiter.find_button_data(resp, text_contains="E2E Экзамен Кофе", data_prefix="exam_view:")
+        assert exam_btn, f"Exam not in list. Buttons: {recruiter.get_button_texts(resp)}"
+
+
+# =========================================================================
+# Класс 2: Меню рекрутера — полный набор кнопок
+# =========================================================================
+
+
+class TestRecruiterExamMenu:
+    """Проверяем полный набор кнопок рекрутера и карточку экзамена."""
+
+    async def test_step1_recruiter_sees_full_menu(self, recruiter: BotClient):
+        """Рекрутер видит все кнопки: создать, провести, сдать, список экзаменов."""
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        buttons = recruiter.get_button_texts(resp)
+
+        assert any("Создать экзамен" in b for b in buttons), f"No 'Создать'. Buttons: {buttons}"
+        assert any("Провести экзамен" in b for b in buttons), f"No 'Провести'. Buttons: {buttons}"
+        assert any("Сдать экзамен" in b for b in buttons), f"No 'Сдать'. Buttons: {buttons}"
+        assert any("E2E Экзамен Кофе" in b for b in buttons), f"No exam in list. Buttons: {buttons}"
+
+    async def test_step2_recruiter_sees_exam_card_with_delete_and_assign(self, recruiter: BotClient):
+        """Рекрутер видит карточку экзамена с кнопками «Удалить» и «Назначить»."""
+        await wait_between_actions()
+
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        exam_btn = recruiter.find_button_data(resp, text_contains="E2E Экзамен Кофе", data_prefix="exam_view:")
+        assert exam_btn, f"Exam button not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(
+            resp, data=exam_btn, wait_pattern="Экзамен.*E2E Экзамен Кофе|E2E Экзамен Кофе"
+        )
+
+        buttons = recruiter.get_button_texts(resp)
+        assert any("Удалить" in b for b in buttons), f"No 'Удалить' button. Buttons: {buttons}"
+        assert any("Назначить" in b for b in buttons), f"No 'Назначить' button. Buttons: {buttons}"
+
+
+# =========================================================================
+# Класс 3: Меню наставника
+# =========================================================================
+
+
+class TestMentorExamMenu:
+    """Наставник видит список экзаменов и может назначить, но не создать/провести."""
+
+    async def test_step1_mentor_opens_exam_menu(self, mentor: BotClient):
+        """Наставник открывает экзамены через reply-кнопку (обходит state.clear в inline меню)."""
+        resp = await mentor.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+
+        buttons = mentor.get_button_texts(resp)
+
+        # Наставник ВИДИТ: «Сдать экзамен», экзамен в списке
+        assert any("Сдать экзамен" in b for b in buttons), f"No 'Сдать' button. Buttons: {buttons}"
+        assert any("E2E Экзамен Кофе" in b for b in buttons), f"No exam in list. Buttons: {buttons}"
+
+        # Наставник НЕ видит: «Создать экзамен»
+        assert not any("Создать экзамен" in b for b in buttons), f"'Создать' should NOT be visible. Buttons: {buttons}"
+        # Наставник НЕ экзаменатор → НЕ видит «Провести экзамен»
+        assert not any("Провести экзамен" in b for b in buttons), (
+            f"'Провести' should NOT be visible. Buttons: {buttons}"
+        )
+
+    async def test_step2_mentor_sees_assign_button_on_card(self, mentor: BotClient):
+        """Наставник видит кнопку «Назначить» на карточке, но не «Удалить»."""
+        await wait_between_actions()
+
+        resp = await mentor.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+
+        exam_btn = mentor.find_button_data(resp, text_contains="E2E Экзамен Кофе", data_prefix="exam_view:")
+        assert exam_btn, f"Exam button not found. Buttons: {mentor.get_button_texts(resp)}"
+
+        resp = await mentor.click_and_wait(resp, data=exam_btn, wait_pattern="E2E Экзамен Кофе")
+
+        buttons = mentor.get_button_texts(resp)
+        assert any("Назначить" in b for b in buttons), f"No 'Назначить' button. Buttons: {buttons}"
+        assert not any("Удалить" in b for b in buttons), f"'Удалить' should NOT be visible. Buttons: {buttons}"
+
+
+# =========================================================================
+# Класс 4: Меню руководителя
+# =========================================================================
+
+
+class TestManagerExamMenu:
+    """Руководитель: провести/сдать, без создания и списка экзаменов."""
+
+    async def test_step1_manager_sees_limited_menu(self, manager: BotClient):
+        """Руководитель видит «Провести» и «Сдать», но не «Создать» и не список."""
+        resp = await manager.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        buttons = manager.get_button_texts(resp)
+
+        assert any("Провести экзамен" in b for b in buttons), f"No 'Провести'. Buttons: {buttons}"
+        assert any("Сдать экзамен" in b for b in buttons), f"No 'Сдать'. Buttons: {buttons}"
+
+        # Руководитель НЕ видит
+        assert not any("Создать экзамен" in b for b in buttons), f"'Создать' should NOT be visible. Buttons: {buttons}"
+        assert not any("E2E Экзамен Кофе" in b for b in buttons), f"Exam list should NOT be visible. Buttons: {buttons}"
+
+
+# =========================================================================
+# Класс 5: Меню сотрудника
+# =========================================================================
+
+
+class TestEmployeeExamMenu:
+    """Сотрудник (trainee2 стал сотрудником в order=2): провести/сдать, без создания/списка."""
+
+    async def test_step1_employee_sees_limited_menu(self, trainee2: BotClient):
+        """Сотрудник видит «Провести» и «Сдать», но не «Создать» и не список."""
+        resp = await trainee2.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        buttons = trainee2.get_button_texts(resp)
+
+        assert any("Провести экзамен" in b for b in buttons), f"No 'Провести'. Buttons: {buttons}"
+        assert any("Сдать экзамен" in b for b in buttons), f"No 'Сдать'. Buttons: {buttons}"
+
+        # Сотрудник НЕ видит
+        assert not any("Создать экзамен" in b for b in buttons), f"'Создать' should NOT be visible. Buttons: {buttons}"
+        assert not any("E2E Экзамен Кофе" in b for b in buttons), f"Exam list should NOT be visible. Buttons: {buttons}"
+
+
+# =========================================================================
+# Класс 6: Стажёр заблокирован
+# =========================================================================
+
+
+class TestTraineeExamBlocked:
+    """Стажёр не может открыть экзамены."""
+
+    async def test_step1_trainee_cannot_access_exams(self, trainee1: BotClient):
+        """Стажёр получает отказ при попытке открыть экзамены."""
+        resp = await trainee1.send_and_wait("Экзамены 📝", pattern="не доступны|стажёр|Стажёр|не найден")
+        resp_text = resp.text or ""
+        assert "не доступны" in resp_text.lower() or "стажёр" in resp_text.lower(), (
+            f"Expected access denied for trainee. Response: {resp_text[:300]}"
+        )
+
+
+# =========================================================================
+# Класс 7: Рекрутер назначает экзамен
+# =========================================================================
+
+
+class TestExamAssignment:
+    """Рекрутер назначает экзамен: экзаменатор=Руководителев, сдающий=Наставников."""
+
+    async def test_step1_open_exam_card_and_assign(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер открывает карточку экзамена и нажимает «Назначить»."""
+        await wait_between_actions()
+
+        resp = await recruiter.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        exam_btn = recruiter.find_button_data(resp, text_contains="E2E Экзамен Кофе", data_prefix="exam_view:")
+        assert exam_btn, f"Exam button not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(resp, data=exam_btn, wait_pattern="E2E Экзамен Кофе")
+
+        assign_btn = recruiter.find_button_data(resp, data_prefix="exam_assign:")
+        assert assign_btn, f"Assign button not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(resp, data=assign_btn, wait_pattern="Экзаменатор|экзаменатор")
+
+        shared_state["exam_assign_resp"] = resp
+
+    async def test_step2_select_examiner(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер выбирает руководителя как экзаменатора."""
+        resp = shared_state.get("exam_assign_resp")
+        if not resp:
+            pytest.skip("No assign response from previous step")
+
+        examiner_btn = recruiter.find_button_data(resp, text_contains="Руководителев", data_prefix="exam_examiner:")
+        assert examiner_btn, f"Examiner button not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(resp, data=examiner_btn, wait_pattern="Сдающий|способ поиска")
+
+        shared_state["exam_filter_resp"] = resp
+
+    async def test_step3_filter_all_select_examinee(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер выбирает «Все пользователи» и находит наставника."""
+        resp = shared_state.get("exam_filter_resp")
+        if not resp:
+            pytest.skip("No filter response from previous step")
+
+        # Нажимаем «Все пользователи»
+        all_btn = recruiter.find_button_data(resp, data_prefix="ef_all")
+        assert all_btn, f"'All users' button not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(resp, data=all_btn, wait_pattern="Найдено|Выбери")
+
+        # Ищем наставника
+        examinee_btn = recruiter.find_button_data(resp, text_contains="Наставников", data_prefix="ef_user:")
+        assert examinee_btn, f"Examinee not found. Buttons: {recruiter.get_button_texts(resp)}"
+
+        resp = await recruiter.click_and_wait(
+            resp, data=examinee_btn, wait_pattern="Карточка|Назначить экзамен|Назначить"
+        )
+
+        shared_state["exam_examinee_card_resp"] = resp
+
+    async def test_step4_confirm_assignment(self, recruiter: BotClient, shared_state: dict):
+        """Рекрутер подтверждает назначение экзамена."""
+        resp = shared_state.get("exam_examinee_card_resp")
+        if not resp:
+            pytest.skip("No examinee card from previous step")
+
+        resp = await recruiter.click_and_wait(resp, data=b"exam_confirm_assign", wait_pattern="ЭКЗАМЕН НАЗНАЧЕН")
+
+        resp_text = resp.text or ""
+        assert "Руководителев" in resp_text, f"Examiner name not in response: {resp_text[:300]}"
+        assert "Наставников" in resp_text, f"Examinee name not in response: {resp_text[:300]}"
+        shared_state["exam_assigned"] = True
+
+    async def test_step5_examiner_receives_notification(self, manager: BotClient, shared_state: dict):
+        """Руководитель (экзаменатор) получает уведомление о назначении."""
+        if not shared_state.get("exam_assigned"):
+            pytest.skip("Exam was not assigned — previous steps failed")
+        await wait_between_actions(3.0)
+
+        messages = await manager.get_messages(limit=10)
+        found = False
+        for msg in messages:
+            if msg.out:
+                continue
+            text = msg.text or ""
+            if "назначен экзамен для проведения" in text.lower() or "назначен экзамен" in text.lower():
+                assert "E2E Экзамен Кофе" in text, f"Exam name not in notification: {text[:300]}"
+                assert "Наставников" in text, f"Examinee name not in notification: {text[:300]}"
+                found = True
+                break
+
+        assert found, (
+            f"Examiner notification not found. Last messages: {[m.text[:100] for m in messages if not m.out][:5]}"
+        )
+
+    async def test_step6_examinee_receives_notification(self, mentor: BotClient, shared_state: dict):
+        """Наставник (сдающий) получает уведомление о назначении."""
+        if not shared_state.get("exam_assigned"):
+            pytest.skip("Exam was not assigned — previous steps failed")
+        messages = await mentor.get_messages(limit=10)
+        found = False
+        for msg in messages:
+            if msg.out:
+                continue
+            text = msg.text or ""
+            if "назначен Экзамен" in text or "назначен экзамен" in text.lower():
+                assert "E2E Экзамен Кофе" in text, f"Exam name not in notification: {text[:300]}"
+                assert "Руководителев" in text, f"Examiner name not in notification: {text[:300]}"
+                found = True
+                break
+
+        assert found, (
+            f"Examinee notification not found. Last messages: {[m.text[:100] for m in messages if not m.out][:5]}"
+        )
+
+
+# =========================================================================
+# Класс 8: Руководитель проводит экзамен
+# =========================================================================
+
+
+class TestExamConducting:
+    """Руководитель проводит экзамен: вопросы, баллы, результат."""
+
+    async def test_step1_examiner_opens_conduct_menu(self, manager: BotClient, shared_state: dict):
+        """Руководитель открывает «Провести экзамен» и видит сдающего."""
+        if not shared_state.get("exam_assigned"):
+            pytest.skip("Exam was not assigned — previous steps failed")
+        await wait_between_actions()
+
+        resp = await manager.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        resp = await manager.click_and_wait(
+            resp, data=b"exam_conduct", wait_pattern="готовы пройти|сотрудник|Наставников"
+        )
+
+        buttons = manager.get_button_texts(resp)
+        assert any("Наставников" in b for b in buttons), (
+            f"Examinee 'Наставников' not in conduct list. Buttons: {buttons}"
+        )
+        shared_state["exam_conduct_resp"] = resp
+
+    async def test_step2_select_and_view_details(self, manager: BotClient, shared_state: dict):
+        """Руководитель выбирает сдающего и видит карточку экзамена."""
+        resp = shared_state.get("exam_conduct_resp")
+        if not resp:
+            pytest.skip("No conduct response from previous step")
+
+        conduct_btn = manager.find_button_data(resp, text_contains="Наставников", data_prefix="exam_conduct_select:")
+        assert conduct_btn, f"Conduct button not found. Buttons: {manager.get_button_texts(resp)}"
+
+        resp = await manager.click_and_wait(resp, data=conduct_btn, wait_pattern="Начать экзамен|Управление")
+
+        buttons = manager.get_button_texts(resp)
+        assert any("Начать экзамен" in b for b in buttons), f"'Начать экзамен' button not found. Buttons: {buttons}"
+        shared_state["exam_detail_resp"] = resp
+
+    async def test_step3_start_exam(self, manager: BotClient, shared_state: dict):
+        """Руководитель начинает экзамен: старт → подтверждение → вопрос 1."""
+        resp = shared_state.get("exam_detail_resp")
+        if not resp:
+            pytest.skip("No detail response from previous step")
+
+        # Нажимаем «Начать экзамен»
+        start_btn = manager.find_button_data(resp, data_prefix="exam_start:")
+        assert start_btn, f"Start button not found. Buttons: {manager.get_button_texts(resp)}"
+
+        resp = await manager.click_and_wait(resp, data=start_btn, wait_pattern="Начать|Да")
+
+        # Подтверждаем
+        resp = await manager.click_and_wait(resp, data=b"exam_confirm_start", wait_pattern="Вопрос 1")
+
+        resp_text = resp.text or ""
+        assert "Правильно ли приготовлен эспрессо" in resp_text, (
+            f"Question 1 text not found. Response: {resp_text[:300]}"
+        )
+        shared_state["exam_q1_resp"] = resp
+
+    async def test_step4_score_question_1(self, manager: BotClient, shared_state: dict):
+        """Руководитель ставит 8 баллов за вопрос 1."""
+        if not shared_state.get("exam_q1_resp"):
+            pytest.skip("Exam was not started — previous steps failed")
+        resp = await manager.send_and_wait("8", pattern="Вопрос 2|принят")
+
+        resp_text = resp.text or ""
+        # Бот отправляет «принят» и потом вопрос 2
+        # settling захватит последнее сообщение
+        shared_state["exam_q2_shown"] = True
+
+    async def test_step5_score_question_2(self, manager: BotClient, shared_state: dict):
+        """Руководитель ставит 7 баллов за вопрос 2 → результат."""
+        if not shared_state.get("exam_q2_shown"):
+            pytest.skip("Question 2 was not shown — previous steps failed")
+        await wait_between_actions()
+
+        resp = await manager.send_and_wait("7", pattern="пройден|результат|Набрано")
+
+        shared_state["exam_result_resp"] = resp
+
+    async def test_step6_verify_result(self, manager: BotClient, shared_state: dict):
+        """Проверяем результат: сумма 15, экзамен пройден."""
+        if not shared_state.get("exam_result_resp"):
+            pytest.skip("Exam result not received — previous steps failed")
+        await wait_between_actions(2.0)
+
+        messages = await manager.get_messages(limit=5)
+        result_found = False
+
+        for msg in messages:
+            if msg.out:
+                continue
+            text = msg.text or ""
+            if "пройден" in text.lower() and "Экзамен" in text:
+                assert "15" in text, f"Score 15 not found in result: {text[:300]}"
+                assert "не пройден" not in text.lower(), f"Exam should be passed but got: {text[:300]}"
+                result_found = True
+                shared_state["exam_result_text"] = text
+                break
+
+        assert result_found, (
+            f"Result message not found. Last messages: {[m.text[:100] for m in messages if not m.out][:5]}"
+        )
+
+    async def test_step7_examinee_gets_result_notification(self, mentor: BotClient, shared_state: dict):
+        """Наставник (сдающий) получает уведомление о результате экзамена."""
+        if not shared_state.get("exam_result_text"):
+            pytest.skip("Exam was not completed — previous steps failed")
+        await wait_between_actions(2.0)
+
+        messages = await mentor.get_messages(limit=10)
+        found = False
+
+        for msg in messages:
+            if msg.out:
+                continue
+            text = msg.text or ""
+            if "E2E Экзамен Кофе" in text and "пройден" in text.lower():
+                found = True
+                break
+
+        assert found, (
+            f"Result notification not found for examinee. Last messages: "
+            f"{[m.text[:100] for m in messages if not m.out][:5]}"
+        )
+
+
+# =========================================================================
+# Класс 9: Наставник видит завершённый экзамен в «Сдать экзамен»
+# =========================================================================
+
+
+class TestExamExamineeView:
+    """Наставник (сдающий) видит свой завершённый экзамен."""
+
+    async def test_step1_examinee_sees_completed_exam(self, mentor: BotClient, shared_state: dict):
+        """Наставник открывает «Сдать экзамен» и видит E2E Экзамен Кофе со статусом ✅."""
+        if not shared_state.get("exam_result_text"):
+            pytest.skip("Exam was not completed — previous steps failed")
+        await wait_between_actions()
+
+        resp = await mentor.send_and_wait("Экзамены 📝", pattern="РЕДАКТОР")
+        resp = await mentor.click_and_wait(resp, data=b"exam_take", wait_pattern="Мои экзамены|экзамен")
+
+        resp_text = resp.text or ""
+        assert "E2E Экзамен Кофе" in resp_text, f"Exam not found in examinee's list. Response: {resp_text[:300]}"
+        # Статус должен быть «Пройден» (✅)
+        assert "✅" in resp_text or "Пройден" in resp_text, f"Expected ✅/Пройден status. Response: {resp_text[:300]}"

--- a/src/tests/unit/exams/test_exam_conducting.py
+++ b/src/tests/unit/exams/test_exam_conducting.py
@@ -1,0 +1,554 @@
+"""
+Unit-тесты для handlers/exams/exam_conducting.py.
+
+Проверяют корректное отображение internship_object и work_object
+в карточке проведения экзамена и в результатах.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# --- Фабрики моков ---
+
+
+def make_callback(user_id=123, data="exam_conduct"):
+    """Создаёт мок CallbackQuery."""
+    callback = AsyncMock()
+    callback.from_user = MagicMock()
+    callback.from_user.id = user_id
+    callback.data = data
+    callback.message = AsyncMock()
+    callback.message.edit_text = AsyncMock()
+    callback.answer = AsyncMock()
+    return callback
+
+
+def make_state(data=None):
+    """Создаёт мок FSMContext."""
+    state = AsyncMock()
+    state.get_data = AsyncMock(return_value=data or {"company_id": 1})
+    state.set_state = AsyncMock()
+    state.update_data = AsyncMock()
+    state.clear = AsyncMock()
+    return state
+
+
+def make_user(user_id=1, tg_id=123, full_name="Тестовый Пользователь"):
+    """Создаёт мок пользователя."""
+    user = MagicMock()
+    user.id = user_id
+    user.tg_id = tg_id
+    user.full_name = full_name
+    return user
+
+
+def make_question(question_id=1, text="Вопрос?", max_points=10.0):
+    """Создаёт мок вопроса экзамена."""
+    q = MagicMock()
+    q.id = question_id
+    q.question_text = text
+    q.max_points = max_points
+    return q
+
+
+def make_exam(name="Тест Экзамен", passing_score=5.0, questions=None):
+    """Создаёт мок экзамена."""
+    exam = MagicMock()
+    exam.name = name
+    exam.passing_score = passing_score
+    exam.questions = questions or [make_question()]
+    return exam
+
+
+def make_assignment(
+    assignment_id=42,
+    examinee_name="Сдающий Тест",
+    exam_name="Тест Экзамен",
+    internship_object_name=None,
+    work_object_name=None,
+    manager_name="Экзаменатор Тест",
+):
+    """Создаёт мок назначения экзамена с trainee, attestation, manager."""
+    internship_obj = None
+    if internship_object_name:
+        internship_obj = MagicMock()
+        internship_obj.name = internship_object_name
+
+    work_obj = None
+    if work_object_name:
+        work_obj = MagicMock()
+        work_obj.name = work_object_name
+
+    trainee = MagicMock()
+    trainee.full_name = examinee_name
+    trainee.tg_id = 456
+    trainee.internship_object = internship_obj
+    trainee.work_object = work_obj
+
+    exam = make_exam(name=exam_name)
+
+    manager = MagicMock()
+    manager.full_name = manager_name
+
+    assignment = MagicMock()
+    assignment.id = assignment_id
+    assignment.trainee = trainee
+    assignment.attestation = exam
+    assignment.manager = manager
+    assignment.manager_id = 20
+    assignment.status = "assigned"
+
+    return assignment
+
+
+# ==========================================================================
+# callback_exam_conduct — список для экзаменатора
+# ==========================================================================
+
+
+class TestCallbackExamConduct:
+    """Список назначенных экзаменов для экзаменатора."""
+
+    @pytest.mark.asyncio
+    async def test_shows_work_object_in_list(self):
+        """В списке сдающих отображается объект работы."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct
+
+        callback = make_callback()
+        state = make_state()
+        session = AsyncMock()
+
+        user = make_user()
+        assignment = make_assignment(work_object_name="Кафе Юг")
+
+        repo_mock = MagicMock()
+        repo_mock.get_exam_assignments_for_examiner = AsyncMock(return_value=[assignment])
+
+        with (
+            patch("bot.handlers.exams.exam_conducting.get_user_by_tg_id", return_value=user),
+            patch("bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository", return_value=repo_mock),
+        ):
+            await callback_exam_conduct(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "Кафе Юг" in text
+
+    @pytest.mark.asyncio
+    async def test_shows_not_specified_when_no_work_object(self):
+        """Если work_object=None, показывается 'Не указан'."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct
+
+        callback = make_callback()
+        state = make_state()
+        session = AsyncMock()
+
+        user = make_user()
+        assignment = make_assignment(work_object_name=None)
+
+        repo_mock = MagicMock()
+        repo_mock.get_exam_assignments_for_examiner = AsyncMock(return_value=[assignment])
+
+        with (
+            patch("bot.handlers.exams.exam_conducting.get_user_by_tg_id", return_value=user),
+            patch("bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository", return_value=repo_mock),
+        ):
+            await callback_exam_conduct(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "Не указан" in text
+
+    @pytest.mark.asyncio
+    async def test_empty_assignments(self):
+        """Если нет назначенных экзаменов, показывается сообщение."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct
+
+        callback = make_callback()
+        state = make_state()
+        session = AsyncMock()
+
+        user = make_user()
+
+        repo_mock = MagicMock()
+        repo_mock.get_exam_assignments_for_examiner = AsyncMock(return_value=[])
+
+        with (
+            patch("bot.handlers.exams.exam_conducting.get_user_by_tg_id", return_value=user),
+            patch("bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository", return_value=repo_mock),
+        ):
+            await callback_exam_conduct(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "Нет назначенных экзаменов" in text
+
+
+# ==========================================================================
+# callback_exam_conduct_select — карточка управления экзаменом
+# ==========================================================================
+
+
+class TestCallbackExamConductSelect:
+    """Карточка сдающего при проведении экзамена."""
+
+    @pytest.mark.asyncio
+    async def test_shows_both_objects(self):
+        """Карточка показывает и объект стажировки, и объект работы."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct_select
+
+        callback = make_callback(data="exam_conduct_select:42")
+        state = make_state()
+        session = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name="Кафе Центр",
+            work_object_name="Кафе Юг",
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+
+        with patch(
+            "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+            return_value=repo_mock,
+        ):
+            await callback_exam_conduct_select(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "Кафе Центр" in text
+        assert "Кафе Юг" in text
+        assert "Объект стажировки" in text
+        assert "Объект работы" in text
+
+    @pytest.mark.asyncio
+    async def test_shows_not_specified_when_internship_object_none(self):
+        """Если internship_object=None, показывается 'Не указан'."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct_select
+
+        callback = make_callback(data="exam_conduct_select:42")
+        state = make_state()
+        session = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name=None,
+            work_object_name="Кафе Юг",
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+
+        with patch(
+            "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+            return_value=repo_mock,
+        ):
+            await callback_exam_conduct_select(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        # "Объект стажировки: Не указан"
+        assert "Не указан" in text
+        assert "Кафе Юг" in text
+
+    @pytest.mark.asyncio
+    async def test_shows_not_specified_when_work_object_none(self):
+        """Если work_object=None, показывается 'Не указан'."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct_select
+
+        callback = make_callback(data="exam_conduct_select:42")
+        state = make_state()
+        session = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name="Кафе Центр",
+            work_object_name=None,
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+
+        with patch(
+            "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+            return_value=repo_mock,
+        ):
+            await callback_exam_conduct_select(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "Кафе Центр" in text
+        # work_object: Не указан
+        assert "Не указан" in text
+
+    @pytest.mark.asyncio
+    async def test_both_objects_none(self):
+        """Если оба объекта None, оба показываются как 'Не указан'."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct_select
+
+        callback = make_callback(data="exam_conduct_select:42")
+        state = make_state()
+        session = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name=None,
+            work_object_name=None,
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+
+        with patch(
+            "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+            return_value=repo_mock,
+        ):
+            await callback_exam_conduct_select(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        # Оба поля "Не указан"
+        assert text.count("Не указан") == 2
+
+    @pytest.mark.asyncio
+    async def test_assignment_not_found(self):
+        """Если назначение не найдено, показывается сообщение об ошибке."""
+        from bot.handlers.exams.exam_conducting import callback_exam_conduct_select
+
+        callback = make_callback(data="exam_conduct_select:999")
+        state = make_state()
+        session = AsyncMock()
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=None)
+
+        with patch(
+            "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+            return_value=repo_mock,
+        ):
+            await callback_exam_conduct_select(callback, state, session)
+
+        text = callback.message.edit_text.call_args[0][0]
+        assert "не найден" in text
+
+
+# ==========================================================================
+# _show_exam_results — результаты экзамена
+# ==========================================================================
+
+
+class TestShowExamResults:
+    """Отображение результатов экзамена."""
+
+    @pytest.mark.asyncio
+    async def test_results_show_both_objects(self):
+        """Результаты экзамена показывают и объект стажировки, и объект работы."""
+        from bot.handlers.exams.exam_conducting import _show_exam_results
+
+        message = AsyncMock()
+        message.answer = AsyncMock()
+        message.from_user = MagicMock()
+        message.from_user.id = 123
+        message.bot = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name="Кафе Центр",
+            work_object_name="Кафе Юг",
+        )
+        assignment.attestation.passing_score = 5.0
+
+        answers = [{"question_id": 1, "score": 8.0, "max_score": 10.0}]
+
+        state = make_state(
+            data={
+                "company_id": 1,
+                "exam_assignment_id": 42,
+                "exam_answers": answers,
+            }
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+        repo_mock.complete_session = AsyncMock(return_value=True)
+
+        result_mock = MagicMock()
+        result_mock.id = 1
+        result_repo_mock = MagicMock()
+        result_repo_mock.create = AsyncMock(return_value=result_mock)
+        result_repo_mock.save_question_result = AsyncMock()
+
+        session = AsyncMock()
+
+        with (
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+                return_value=repo_mock,
+            ),
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentResultRepository",
+                return_value=result_repo_mock,
+            ),
+        ):
+            await _show_exam_results(message, state, session)
+
+        text = message.answer.call_args[0][0]
+        assert "Кафе Центр" in text
+        assert "Кафе Юг" in text
+        assert "Объект стажировки" in text
+        assert "Объект работы" in text
+
+    @pytest.mark.asyncio
+    async def test_results_show_not_specified_when_objects_none(self):
+        """Результаты показывают 'Не указан' когда объекты отсутствуют."""
+        from bot.handlers.exams.exam_conducting import _show_exam_results
+
+        message = AsyncMock()
+        message.answer = AsyncMock()
+        message.from_user = MagicMock()
+        message.from_user.id = 123
+        message.bot = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name=None,
+            work_object_name=None,
+        )
+        assignment.attestation.passing_score = 5.0
+
+        answers = [{"question_id": 1, "score": 3.0, "max_score": 10.0}]
+
+        state = make_state(
+            data={
+                "company_id": 1,
+                "exam_assignment_id": 42,
+                "exam_answers": answers,
+            }
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+        repo_mock.complete_session = AsyncMock(return_value=True)
+
+        result_mock = MagicMock()
+        result_mock.id = 1
+        result_repo_mock = MagicMock()
+        result_repo_mock.create = AsyncMock(return_value=result_mock)
+        result_repo_mock.save_question_result = AsyncMock()
+
+        session = AsyncMock()
+
+        with (
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+                return_value=repo_mock,
+            ),
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentResultRepository",
+                return_value=result_repo_mock,
+            ),
+        ):
+            await _show_exam_results(message, state, session)
+
+        text = message.answer.call_args[0][0]
+        assert text.count("Не указан") == 2
+
+    @pytest.mark.asyncio
+    async def test_passed_exam_result(self):
+        """Экзамен пройден — отображается зелёный статус."""
+        from bot.handlers.exams.exam_conducting import _show_exam_results
+
+        message = AsyncMock()
+        message.answer = AsyncMock()
+        message.from_user = MagicMock()
+        message.from_user.id = 123
+        message.bot = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name="Кафе Центр",
+            work_object_name="Кафе Юг",
+        )
+        assignment.attestation.passing_score = 5.0
+
+        answers = [{"question_id": 1, "score": 8.0, "max_score": 10.0}]
+
+        state = make_state(
+            data={
+                "company_id": 1,
+                "exam_assignment_id": 42,
+                "exam_answers": answers,
+            }
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+        repo_mock.complete_session = AsyncMock(return_value=True)
+
+        result_mock = MagicMock()
+        result_mock.id = 1
+        result_repo_mock = MagicMock()
+        result_repo_mock.create = AsyncMock(return_value=result_mock)
+        result_repo_mock.save_question_result = AsyncMock()
+
+        session = AsyncMock()
+
+        with (
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+                return_value=repo_mock,
+            ),
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentResultRepository",
+                return_value=result_repo_mock,
+            ),
+        ):
+            await _show_exam_results(message, state, session)
+
+        text = message.answer.call_args[0][0]
+        assert "пройден" in text
+        assert "🟢" in text
+
+    @pytest.mark.asyncio
+    async def test_failed_exam_result(self):
+        """Экзамен не пройден — отображается красный статус."""
+        from bot.handlers.exams.exam_conducting import _show_exam_results
+
+        message = AsyncMock()
+        message.answer = AsyncMock()
+        message.from_user = MagicMock()
+        message.from_user.id = 123
+        message.bot = AsyncMock()
+
+        assignment = make_assignment(
+            internship_object_name="Кафе Центр",
+            work_object_name="Кафе Юг",
+        )
+        assignment.attestation.passing_score = 15.0  # выше чем набрано
+
+        answers = [{"question_id": 1, "score": 3.0, "max_score": 10.0}]
+
+        state = make_state(
+            data={
+                "company_id": 1,
+                "exam_assignment_id": 42,
+                "exam_answers": answers,
+            }
+        )
+
+        repo_mock = MagicMock()
+        repo_mock.get_by_id = AsyncMock(return_value=assignment)
+        repo_mock.complete_session = AsyncMock(return_value=True)
+
+        result_mock = MagicMock()
+        result_mock.id = 1
+        result_repo_mock = MagicMock()
+        result_repo_mock.create = AsyncMock(return_value=result_mock)
+        result_repo_mock.save_question_result = AsyncMock()
+
+        session = AsyncMock()
+
+        with (
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentAssignmentRepository",
+                return_value=repo_mock,
+            ),
+            patch(
+                "bot.handlers.exams.exam_conducting.AssessmentResultRepository",
+                return_value=result_repo_mock,
+            ),
+        ):
+            await _show_exam_results(message, state, session)
+
+        text = message.answer.call_args[0][0]
+        assert "не пройден" in text
+        assert "🔴" in text

--- a/src/tests/unit/keyboards/test_user_filter_keyboards.py
+++ b/src/tests/unit/keyboards/test_user_filter_keyboards.py
@@ -1,0 +1,600 @@
+"""Тесты для класса UserFilterKeyboards — унифицированные клавиатуры фильтрации пользователей."""
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class MockRole:
+    name: str
+
+
+@dataclass
+class MockGroup:
+    id: int
+    name: str
+
+
+@dataclass
+class MockObject:
+    id: int
+    name: str
+
+
+@dataclass
+class MockUser:
+    id: int
+    full_name: str
+    roles: list = field(default_factory=list)
+
+
+def make_groups(n: int) -> list[MockGroup]:
+    return [MockGroup(id=i + 1, name=f"Группа {i + 1}") for i in range(n)]
+
+
+def make_objects(n: int) -> list[MockObject]:
+    return [MockObject(id=i + 1, name=f"Объект {i + 1}") for i in range(n)]
+
+
+def make_users(n: int, with_roles: bool = False) -> list[MockUser]:
+    roles = [MockRole(name="Стажёр")] if with_roles else []
+    return [MockUser(id=i + 1, full_name=f"Иванов {i + 1}", roles=list(roles)) for i in range(n)]
+
+
+def _all_buttons(keyboard):
+    """Все кнопки из клавиатуры плоским списком."""
+    return [btn for row in keyboard.inline_keyboard for btn in row]
+
+
+def _all_callbacks(keyboard):
+    """Все callback_data из клавиатуры."""
+    return [btn.callback_data for btn in _all_buttons(keyboard)]
+
+
+# ===================== Callback data helpers =====================
+
+
+class TestCallbackDataProperties:
+    """Тесты для свойств и методов генерации callback_data."""
+
+    def test_cb_all_uses_prefix(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_all == "ef_all"
+
+    def test_cb_groups_uses_prefix(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        assert kb.cb_groups == "uf_groups"
+
+    def test_cb_objects_uses_prefix(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_objects == "ef_objects"
+
+    def test_cb_search_uses_prefix(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        assert kb.cb_search == "uf_search"
+
+    def test_cb_back_uses_prefix(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_back == "ef_back"
+
+    def test_cb_group_with_id(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_group(42) == "ef_group:42"
+
+    def test_cb_object_with_id(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        assert kb.cb_object(7) == "uf_object:7"
+
+    def test_cb_user_with_id(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_user(99) == "ef_user:99"
+
+    def test_cb_upage(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        assert kb.cb_upage(3) == "uf_upage:3"
+
+    def test_cb_gpage(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        assert kb.cb_gpage(1) == "ef_gpage:1"
+
+    def test_cb_opage(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        assert kb.cb_opage(0) == "uf_opage:0"
+
+
+# ===================== filter_menu =====================
+
+
+class TestFilterMenu:
+    """Тесты для метода filter_menu — меню фильтров."""
+
+    def test_always_has_all_button(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        keyboard = kb.filter_menu([], [])
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_all" in callbacks
+
+    def test_always_has_search_button(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        keyboard = kb.filter_menu([], [])
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_search" in callbacks
+
+    def test_always_has_main_menu_button(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        keyboard = kb.filter_menu([], [])
+        callbacks = _all_callbacks(keyboard)
+        assert "main_menu" in callbacks
+
+    def test_groups_button_shown_when_groups_exist(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        groups = make_groups(2)
+        keyboard = kb.filter_menu(groups, [])
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_groups" in callbacks
+
+    def test_groups_button_hidden_when_no_groups(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        keyboard = kb.filter_menu([], make_objects(1))
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_groups" not in callbacks
+
+    def test_objects_button_shown_when_objects_exist(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        objects = make_objects(3)
+        keyboard = kb.filter_menu([], objects)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_objects" in callbacks
+
+    def test_objects_button_hidden_when_no_objects(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        keyboard = kb.filter_menu(make_groups(1), [])
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_objects" not in callbacks
+
+    def test_emojis_used_in_button_text(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        emojis = {"all": "👥", "groups": "🟢", "objects": "🔴", "search": "🟣"}
+        kb = UserFilterKeyboards(prefix="ef", emojis=emojis)
+        keyboard = kb.filter_menu(make_groups(1), make_objects(1))
+        buttons = _all_buttons(keyboard)
+        texts = [b.text for b in buttons]
+        # Кнопка "Все" должна содержать эмодзи "👥"
+        all_btn = next(b for b in buttons if b.callback_data == "ef_all")
+        assert "👥" in all_btn.text
+        # Кнопка "По группам" — "🟢"
+        groups_btn = next(b for b in buttons if b.callback_data == "ef_groups")
+        assert "🟢" in groups_btn.text
+        # Кнопка "По объектам" — "🔴"
+        objects_btn = next(b for b in buttons if b.callback_data == "ef_objects")
+        assert "🔴" in objects_btn.text
+        # Кнопка "Поиск" — "🟣"
+        search_btn = next(b for b in buttons if b.callback_data == "ef_search")
+        assert "🟣" in search_btn.text
+
+    def test_default_emojis(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        keyboard = kb.filter_menu(make_groups(1), make_objects(1))
+        buttons = _all_buttons(keyboard)
+        groups_btn = next(b for b in buttons if b.callback_data == "uf_groups")
+        assert "🗂️" in groups_btn.text
+        objects_btn = next(b for b in buttons if b.callback_data == "uf_objects")
+        assert "📍" in objects_btn.text
+        search_btn = next(b for b in buttons if b.callback_data == "uf_search")
+        assert "🔍" in search_btn.text
+
+
+# ===================== group_list =====================
+
+
+class TestGroupList:
+    """Тесты для метода group_list — список групп с пагинацией."""
+
+    def test_shows_groups_with_correct_callbacks(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        groups = make_groups(3)
+        keyboard = kb.group_list(groups)
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_group:1" in callbacks
+        assert "ef_group:2" in callbacks
+        assert "ef_group:3" in callbacks
+
+    def test_back_button_uses_cb_back(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", back_text="↩️ Назад к фильтрам")
+        keyboard = kb.group_list(make_groups(1))
+        last_row = keyboard.inline_keyboard[-1]
+        assert last_row[0].callback_data == "uf_back"
+        assert last_row[0].text == "↩️ Назад к фильтрам"
+
+    def test_no_nav_on_single_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=5)
+        keyboard = kb.group_list(make_groups(3))
+        callbacks = _all_callbacks(keyboard)
+        assert not any(c.startswith("ef_gpage:") for c in callbacks)
+
+    def test_forward_nav_on_first_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=2)
+        keyboard = kb.group_list(make_groups(5), page=0)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_gpage:1" in callbacks
+        assert not any(c == "uf_gpage:-1" for c in callbacks)
+
+    def test_backward_nav_on_second_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=2)
+        keyboard = kb.group_list(make_groups(5), page=1)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_gpage:0" in callbacks
+        assert "uf_gpage:2" in callbacks
+
+    def test_no_forward_on_last_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=2)
+        keyboard = kb.group_list(make_groups(4), page=1)
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_gpage:0" in callbacks
+        assert "ef_gpage:2" not in callbacks
+
+    def test_pagination_slices_correctly(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=2)
+        groups = make_groups(5)
+        keyboard = kb.group_list(groups, page=1)
+        # Страница 1: группы 3, 4 (индексы 2, 3)
+        group_callbacks = [c for c in _all_callbacks(keyboard) if c.startswith("ef_group:")]
+        assert group_callbacks == ["ef_group:3", "ef_group:4"]
+
+    def test_group_button_text_has_emoji(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        groups = [MockGroup(id=1, name="Кухня")]
+        keyboard = kb.group_list(groups)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "🗂️" in btn.text
+        assert "Кухня" in btn.text
+
+
+# ===================== object_list =====================
+
+
+class TestObjectList:
+    """Тесты для метода object_list — список объектов с пагинацией."""
+
+    def test_shows_objects_with_correct_callbacks(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        objects = make_objects(2)
+        keyboard = kb.object_list(objects)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_object:1" in callbacks
+        assert "uf_object:2" in callbacks
+
+    def test_back_button(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", back_text="🔙 Назад")
+        keyboard = kb.object_list(make_objects(1))
+        last_row = keyboard.inline_keyboard[-1]
+        assert last_row[0].callback_data == "ef_back"
+        assert last_row[0].text == "🔙 Назад"
+
+    def test_pagination_callbacks(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=2)
+        keyboard = kb.object_list(make_objects(5), page=0)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_opage:1" in callbacks
+
+    def test_no_nav_on_single_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=10)
+        keyboard = kb.object_list(make_objects(3))
+        callbacks = _all_callbacks(keyboard)
+        assert not any(c.startswith("ef_opage:") for c in callbacks)
+
+    def test_object_button_text_has_emoji(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf")
+        objects = [MockObject(id=1, name="Кафе Пушкин")]
+        keyboard = kb.object_list(objects)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "📍" in btn.text
+        assert "Кафе Пушкин" in btn.text
+
+    def test_pagination_slices_correctly(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=3)
+        objects = make_objects(7)
+        keyboard = kb.object_list(objects, page=2)
+        # Страница 2: объект 7 (индекс 6)
+        obj_callbacks = [c for c in _all_callbacks(keyboard) if c.startswith("uf_object:")]
+        assert obj_callbacks == ["uf_object:7"]
+
+
+# ===================== user_list =====================
+
+
+class TestUserList:
+    """Тесты для метода user_list — список пользователей с пагинацией."""
+
+    def test_shows_users_with_correct_callbacks(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef")
+        users = make_users(3)
+        keyboard = kb.user_list(users)
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_user:1" in callbacks
+        assert "ef_user:2" in callbacks
+        assert "ef_user:3" in callbacks
+
+    def test_show_role_true_includes_role(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", show_role=True)
+        users = [MockUser(id=1, full_name="Иванов", roles=[MockRole(name="Стажёр")])]
+        keyboard = kb.user_list(users)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "Стажёр" in btn.text
+        assert "Иванов" in btn.text
+
+    def test_show_role_false_no_role(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", show_role=False)
+        users = [MockUser(id=1, full_name="Иванов", roles=[MockRole(name="Стажёр")])]
+        keyboard = kb.user_list(users)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "Стажёр" not in btn.text
+        assert "Иванов" in btn.text
+
+    def test_show_role_true_no_roles(self):
+        """Если show_role=True, но у пользователя нет ролей — показываем 'Без роли'."""
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", show_role=True)
+        users = [MockUser(id=1, full_name="Петров", roles=[])]
+        keyboard = kb.user_list(users)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "Без роли" in btn.text
+
+    def test_back_button(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", back_text="🔙 Назад")
+        keyboard = kb.user_list(make_users(1))
+        last_row = keyboard.inline_keyboard[-1]
+        assert last_row[0].callback_data == "ef_back"
+
+    def test_pagination_forward(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=3)
+        keyboard = kb.user_list(make_users(7), page=0)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_upage:1" in callbacks
+
+    def test_pagination_backward(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="uf", per_page=3)
+        keyboard = kb.user_list(make_users(7), page=1)
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_upage:0" in callbacks
+        assert "uf_upage:2" in callbacks
+
+    def test_no_nav_on_single_page(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=10)
+        keyboard = kb.user_list(make_users(5))
+        callbacks = _all_callbacks(keyboard)
+        assert not any(c.startswith("ef_upage:") for c in callbacks)
+
+    def test_pagination_slices_correctly(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=2)
+        users = make_users(5)
+        keyboard = kb.user_list(users, page=2)
+        # Страница 2: пользователь 5 (индекс 4)
+        user_callbacks = [c for c in _all_callbacks(keyboard) if c.startswith("ef_user:")]
+        assert user_callbacks == ["ef_user:5"]
+
+    def test_per_page_respected(self):
+        from bot.keyboards.keyboards import UserFilterKeyboards
+
+        kb = UserFilterKeyboards(prefix="ef", per_page=2)
+        keyboard = kb.user_list(make_users(10), page=0)
+        user_callbacks = [c for c in _all_callbacks(keyboard) if c.startswith("ef_user:")]
+        assert len(user_callbacks) == 2
+
+
+# ===================== Два инстанса =====================
+
+
+class TestExamFiltersInstance:
+    """Тесты для инстанса exam_filters."""
+
+    def test_prefix_is_ef(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        assert exam_filters.prefix == "ef"
+
+    def test_per_page_is_8(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        assert exam_filters.per_page == 8
+
+    def test_show_role_is_false(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        assert exam_filters.show_role is False
+
+    def test_emojis_custom(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        assert exam_filters.emojis["groups"] == "🟢"
+        assert exam_filters.emojis["objects"] == "🔴"
+        assert exam_filters.emojis["search"] == "🟣"
+
+    def test_back_text(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        assert exam_filters.back_text == "🔙 Назад"
+
+    def test_filter_menu_callbacks(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        keyboard = exam_filters.filter_menu(make_groups(1), make_objects(1))
+        callbacks = _all_callbacks(keyboard)
+        assert "ef_all" in callbacks
+        assert "ef_groups" in callbacks
+        assert "ef_objects" in callbacks
+        assert "ef_search" in callbacks
+
+    def test_user_list_no_role_in_text(self):
+        from bot.keyboards.keyboards import exam_filters
+
+        users = [MockUser(id=1, full_name="Иванов", roles=[MockRole(name="Стажёр")])]
+        keyboard = exam_filters.user_list(users)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "Стажёр" not in btn.text
+
+
+class TestUserEditFiltersInstance:
+    """Тесты для инстанса user_edit_filters."""
+
+    def test_prefix_is_uf(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        assert user_edit_filters.prefix == "uf"
+
+    def test_per_page_is_5(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        assert user_edit_filters.per_page == 5
+
+    def test_show_role_is_true(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        assert user_edit_filters.show_role is True
+
+    def test_emojis_default_style(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        assert user_edit_filters.emojis["groups"] == "🗂️"
+        assert user_edit_filters.emojis["objects"] == "📍"
+        assert user_edit_filters.emojis["search"] == "🔍"
+
+    def test_back_text(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        assert user_edit_filters.back_text == "↩️ Назад к фильтрам"
+
+    def test_filter_menu_callbacks(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        keyboard = user_edit_filters.filter_menu(make_groups(1), make_objects(1))
+        callbacks = _all_callbacks(keyboard)
+        assert "uf_all" in callbacks
+        assert "uf_groups" in callbacks
+        assert "uf_objects" in callbacks
+        assert "uf_search" in callbacks
+
+    def test_user_list_shows_role(self):
+        from bot.keyboards.keyboards import user_edit_filters
+
+        users = [MockUser(id=1, full_name="Иванов", roles=[MockRole(name="Стажёр")])]
+        keyboard = user_edit_filters.user_list(users)
+        btn = keyboard.inline_keyboard[0][0]
+        assert "Стажёр" in btn.text
+
+
+# ===================== Различия между инстансами =====================
+
+
+class TestInstancesProduceDifferentCallbacks:
+    """Проверяем, что два инстанса генерируют разные callback_data."""
+
+    def test_filter_menu_callbacks_differ(self):
+        from bot.keyboards.keyboards import exam_filters, user_edit_filters
+
+        groups = make_groups(1)
+        objects = make_objects(1)
+        ef_callbacks = set(_all_callbacks(exam_filters.filter_menu(groups, objects)))
+        uf_callbacks = set(_all_callbacks(user_edit_filters.filter_menu(groups, objects)))
+        # Общий — только main_menu
+        common = ef_callbacks & uf_callbacks
+        assert common == {"main_menu"}
+
+    def test_user_list_callbacks_differ(self):
+        from bot.keyboards.keyboards import exam_filters, user_edit_filters
+
+        users = make_users(3)
+        ef_callbacks = set(_all_callbacks(exam_filters.user_list(users)))
+        uf_callbacks = set(_all_callbacks(user_edit_filters.user_list(users)))
+        assert ef_callbacks.isdisjoint(uf_callbacks)
+
+    def test_group_list_callbacks_differ(self):
+        from bot.keyboards.keyboards import exam_filters, user_edit_filters
+
+        groups = make_groups(2)
+        ef_callbacks = set(_all_callbacks(exam_filters.group_list(groups)))
+        uf_callbacks = set(_all_callbacks(user_edit_filters.group_list(groups)))
+        assert ef_callbacks.isdisjoint(uf_callbacks)

--- a/src/tests/unit/repositories/test_assessment_assignment_repo.py
+++ b/src/tests/unit/repositories/test_assessment_assignment_repo.py
@@ -528,3 +528,333 @@ class TestCleanupDuplicates:
         assert middle.is_active is False
         assert oldest.is_active is False
         session.flush.assert_awaited_once()
+
+
+# ==========================================================================
+# get_users_for_exam_assignment()
+# ==========================================================================
+
+
+def make_scalars_unique_result(items: list) -> MagicMock:
+    """Создать мок результата session.execute() с scalars().unique().all()."""
+    unique_mock = MagicMock()
+    unique_mock.all.return_value = items
+    scalars_mock = MagicMock()
+    scalars_mock.unique.return_value = unique_mock
+    result = MagicMock()
+    result.scalars.return_value = scalars_mock
+    return result
+
+
+class TestGetUsersForExamAssignment:
+    """Получение пользователей для назначения экзамена (исключая стажёров)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_users(self):
+        """get_users_for_exam_assignment() возвращает список пользователей."""
+        session = AsyncMock()
+
+        user1 = MagicMock(id=1, full_name="Рекрутеров Тест")
+        user2 = MagicMock(id=2, full_name="Наставников Тест")
+
+        session.execute.return_value = make_scalars_unique_result([user1, user2])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(company_id=1)
+
+        assert len(result) == 2
+        assert user1 in result
+        assert user2 in result
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self):
+        """get_users_for_exam_assignment() возвращает пустой список, если нет пользователей."""
+        session = AsyncMock()
+        session.execute.return_value = make_scalars_unique_result([])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(company_id=1)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_filter_by_group(self):
+        """get_users_for_exam_assignment() с filter_type='group' выполняет запрос."""
+        session = AsyncMock()
+
+        user1 = MagicMock(id=1)
+        session.execute.return_value = make_scalars_unique_result([user1])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(company_id=1, filter_type="group", filter_id=5)
+
+        assert len(result) == 1
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_filter_by_object(self):
+        """get_users_for_exam_assignment() с filter_type='object' выполняет запрос."""
+        session = AsyncMock()
+
+        user1 = MagicMock(id=1)
+        session.execute.return_value = make_scalars_unique_result([user1])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(company_id=1, filter_type="object", filter_id=3)
+
+        assert len(result) == 1
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_filter_by_search(self):
+        """get_users_for_exam_assignment() с filter_type='search' выполняет запрос."""
+        session = AsyncMock()
+
+        user1 = MagicMock(id=1, full_name="Наставников Тест")
+        session.execute.return_value = make_scalars_unique_result([user1])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(
+            company_id=1, filter_type="search", search_query="Наставников"
+        )
+
+        assert len(result) == 1
+        assert result[0].full_name == "Наставников Тест"
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty_list(self):
+        """get_users_for_exam_assignment() возвращает [] при ошибке."""
+        session = AsyncMock()
+        session.execute.side_effect = Exception("DB error")
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_users_for_exam_assignment(company_id=1)
+
+        assert result == []
+
+
+# ==========================================================================
+# get_by_id() — проверка загрузки internship_object
+# ==========================================================================
+
+
+class TestGetByIdInternshipObject:
+    """Проверка что get_by_id корректно возвращает объект с trainee.internship_object."""
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_returns_trainee_with_internship_object(self):
+        """get_by_id() возвращает назначение, у которого trainee имеет internship_object."""
+        session = AsyncMock()
+
+        internship_obj = MagicMock()
+        internship_obj.name = "Кафе Центр"
+
+        trainee = MagicMock()
+        trainee.full_name = "Наставников Тест"
+        trainee.work_object = MagicMock(name="Кафе Юг")
+        trainee.internship_object = internship_obj
+
+        assignment_mock = MagicMock()
+        assignment_mock.id = 42
+        assignment_mock.trainee = trainee
+
+        session.execute.return_value = make_scalar_one_or_none_result(assignment_mock)
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_by_id(assignment_id=42, company_id=1)
+
+        assert result is assignment_mock
+        assert result.trainee.internship_object.name == "Кафе Центр"
+
+    @pytest.mark.asyncio
+    async def test_get_by_id_trainee_without_internship_object(self):
+        """get_by_id() корректно работает, когда internship_object = None."""
+        session = AsyncMock()
+
+        trainee = MagicMock()
+        trainee.full_name = "Наставников Тест"
+        trainee.work_object = MagicMock(name="Кафе Юг")
+        trainee.internship_object = None
+
+        assignment_mock = MagicMock()
+        assignment_mock.id = 42
+        assignment_mock.trainee = trainee
+
+        session.execute.return_value = make_scalar_one_or_none_result(assignment_mock)
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_by_id(assignment_id=42, company_id=1)
+
+        assert result is assignment_mock
+        assert result.trainee.internship_object is None
+
+
+# ==========================================================================
+# get_exam_assignments_for_examiner()
+# ==========================================================================
+
+
+class TestGetExamAssignmentsForExaminer:
+    """Получение назначенных экзаменов для экзаменатора."""
+
+    @pytest.mark.asyncio
+    async def test_returns_assignments(self):
+        """get_exam_assignments_for_examiner() возвращает список назначений."""
+        session = AsyncMock()
+
+        att1 = MagicMock(id=1, status="assigned")
+        att2 = MagicMock(id=2, status="in_progress")
+
+        session.execute.return_value = make_scalars_result([att1, att2])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_exam_assignments_for_examiner(examiner_id=20, company_id=1)
+
+        assert len(result) == 2
+        assert att1 in result
+        assert att2 in result
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self):
+        """get_exam_assignments_for_examiner() возвращает [] если нет экзаменов."""
+        session = AsyncMock()
+        session.execute.return_value = make_scalars_result([])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_exam_assignments_for_examiner(examiner_id=20, company_id=1)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_returns_trainee_with_internship_object(self):
+        """Назначение содержит trainee с загруженным internship_object."""
+        session = AsyncMock()
+
+        internship_obj = MagicMock()
+        internship_obj.name = "Кафе Центр"
+
+        work_obj = MagicMock()
+        work_obj.name = "Кафе Юг"
+
+        trainee = MagicMock()
+        trainee.full_name = "Тестовый Сдающий"
+        trainee.internship_object = internship_obj
+        trainee.work_object = work_obj
+
+        att = MagicMock(id=1, status="assigned")
+        att.trainee = trainee
+
+        session.execute.return_value = make_scalars_result([att])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_exam_assignments_for_examiner(examiner_id=20, company_id=1)
+
+        assert len(result) == 1
+        assert result[0].trainee.internship_object.name == "Кафе Центр"
+        assert result[0].trainee.work_object.name == "Кафе Юг"
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty_list(self):
+        """get_exam_assignments_for_examiner() возвращает [] при ошибке."""
+        session = AsyncMock()
+        session.execute.side_effect = Exception("DB error")
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_exam_assignments_for_examiner(examiner_id=20, company_id=1)
+
+        assert result == []
+
+
+# ==========================================================================
+# get_examiners()
+# ==========================================================================
+
+
+class TestGetExaminers:
+    """Получение списка экзаменаторов."""
+
+    @pytest.mark.asyncio
+    async def test_returns_examiners(self):
+        """get_examiners() возвращает список экзаменаторов."""
+        session = AsyncMock()
+
+        user1 = MagicMock(id=1, full_name="Руководитель Тест")
+        user2 = MagicMock(id=2, full_name="Рекрутер Тест")
+
+        session.execute.return_value = make_scalars_unique_result([user1, user2])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_examiners(company_id=1)
+
+        assert len(result) == 2
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self):
+        """get_examiners() возвращает [] если нет экзаменаторов."""
+        session = AsyncMock()
+        session.execute.return_value = make_scalars_unique_result([])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_examiners(company_id=1)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty_list(self):
+        """get_examiners() возвращает [] при ошибке."""
+        session = AsyncMock()
+        session.execute.side_effect = Exception("DB error")
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_examiners(company_id=1)
+
+        assert result == []
+
+
+# ==========================================================================
+# get_for_examinee()
+# ==========================================================================
+
+
+class TestGetForExaminee:
+    """Получение назначенных экзаменов для сдающего."""
+
+    @pytest.mark.asyncio
+    async def test_returns_assignments(self):
+        """get_for_examinee() возвращает список назначений экзаменов."""
+        session = AsyncMock()
+
+        att1 = MagicMock(id=1, status="assigned")
+
+        session.execute.return_value = make_scalars_result([att1])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_for_examinee(examinee_id=10, company_id=1)
+
+        assert len(result) == 1
+        session.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_empty_result(self):
+        """get_for_examinee() возвращает [] если нет назначений."""
+        session = AsyncMock()
+        session.execute.return_value = make_scalars_result([])
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_for_examinee(examinee_id=10, company_id=1)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_error_returns_empty_list(self):
+        """get_for_examinee() возвращает [] при ошибке."""
+        session = AsyncMock()
+        session.execute.side_effect = Exception("DB error")
+
+        repo = AssessmentAssignmentRepository(session)
+        result = await repo.get_for_examinee(examinee_id=10, company_id=1)
+
+        assert result == []


### PR DESCRIPTION
## Summary
- Система экзаменов: создание (рекрутер), назначение экзаменатора и сдающих, проведение и сдача
- Новые хэндлеры: `exam_menu`, `exam_assignment`, `exam_conducting`
- Расширение модели `Attestation` полем `assessment_type` для разделения аттестаций и экзаменов
- Фильтрация пользователей при назначении: по группам, объектам, поиск по ФИО; стажёры исключены
- Fix: загрузка `internship_object` в assignment-запросах, исправление краша при проведении

## Изменения
- 3 новых хэндлера: `exam_menu.py`, `exam_assignment.py`, `exam_conducting.py`
- Клавиатуры экзаменов + кнопка «Экзамены 📝» во всех ролевых меню
- FSM-состояния `ExamStates` (13 состояний)
- Репозиторий: `get_examiners`, `get_for_examinee`, `get_exam_assignments_for_examiner`, `get_users_for_exam_assignment`
- Миграция: `ALTER TABLE attestations ADD COLUMN assessment_type`
- Unit-тесты: exam_conducting, user_filter_keyboards, assessment_assignment_repo
- E2E-тесты: полный flow экзаменов

## Test plan
- [ ] `pytest` — unit-тесты проходят
- [ ] E2E: создание экзамена рекрутером, назначение, проведение экзаменатором
- [ ] Проверить что аттестации не затронуты (assessment_type='attestation' по умолчанию)